### PR TITLE
added try/except for selectors import since selectors was moved out of asyncio in python 3.4

### DIFF
--- a/aiozmq/selector.py
+++ b/aiozmq/selector.py
@@ -3,8 +3,10 @@
 
 __all__ = ['ZmqSelector']
 
-
-from asyncio.selectors import BaseSelector, SelectorKey, EVENT_READ, EVENT_WRITE
+try:
+    from asyncio.selectors import BaseSelector, SelectorKey, EVENT_READ, EVENT_WRITE
+except ImportError:
+    from selectors import BaseSelector, SelectorKey, EVENT_READ, EVENT_WRITE
 from collections import Mapping
 from errno import EINTR
 from zmq import (ZMQError, POLLIN, POLLOUT, POLLERR,


### PR DESCRIPTION
To expand on title, selectors was moved out of asyncio in python 3.4 (see: http://docs.python.org/3.4/library/selectors.html#) so 

`from asyncio.selectors import (...)`

does not work any more, you now have to use:

`from selectors import (...)`

Adding a simple try/except ImportError fixes that.
