### PR TITLE
Make connect and bind not mutually exclusive

### DIFF
--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -104,7 +104,7 @@ class ZmqEventLoop(SelectorEventLoop):
                         raise ValueError('bind should be str or iterable')
                 for endpoint in bind:
                     yield from transport.bind(endpoint)
-            elif connect is not None:
+            if connect is not None:
                 if isinstance(connect, str):
                     connect = [connect]
                 else:


### PR DESCRIPTION
ZeroMQ socket can be simultaneously connected and bound to multiple endpoints (each).
There should be no reason for the `connect`/`bind` arguments of `create_zmq_connection()`
being mutually exclusive.
