### PR TITLE
Add socket event monitor capability

### DIFF
--- a/aiozmq/__init__.py
+++ b/aiozmq/__init__.py
@@ -5,15 +5,14 @@ from collections import namedtuple
 import zmq
 
 from .core import ZmqEventLoop, ZmqEventLoopPolicy, create_zmq_connection
-from .interface import (ZmqTransport, ZmqProtocol, ZmqEventProtocol,
-                        MonitorEvents)
+from .interface import ZmqTransport, ZmqProtocol
 from .selector import ZmqSelector
 from .stream import (ZmqStream, ZmqStreamProtocol, ZmqStreamClosed,
                      create_zmq_stream)
 
 
 __all__ = ('ZmqSelector', 'ZmqEventLoop', 'ZmqEventLoopPolicy',
-           'ZmqTransport', 'ZmqProtocol', 'ZmqEventProtocol',
+           'ZmqTransport', 'ZmqProtocol',
            'ZmqStream', 'ZmqStreamProtocol', 'create_zmq_stream',
            'ZmqStreamClosed', 'MonitorEvents',
            'create_zmq_connection',
@@ -56,5 +55,5 @@ if zmq.zmq_version_info()[0] < 3:  # pragma no cover
 
 # make pyflakes happy
 (ZmqSelector, ZmqEventLoop, ZmqEventLoopPolicy, ZmqTransport, ZmqProtocol,
- ZmqEventProtocol, ZmqStream, ZmqStreamProtocol, ZmqStreamClosed,
- MonitorEvents, create_zmq_stream, create_zmq_connection)
+ ZmqStream, ZmqStreamProtocol, ZmqStreamClosed, create_zmq_stream,
+ create_zmq_connection)

--- a/aiozmq/__init__.py
+++ b/aiozmq/__init__.py
@@ -14,7 +14,7 @@ from .stream import (ZmqStream, ZmqStreamProtocol, ZmqStreamClosed,
 __all__ = ('ZmqSelector', 'ZmqEventLoop', 'ZmqEventLoopPolicy',
            'ZmqTransport', 'ZmqProtocol',
            'ZmqStream', 'ZmqStreamProtocol', 'create_zmq_stream',
-           'ZmqStreamClosed', 'MonitorEvents',
+           'ZmqStreamClosed',
            'create_zmq_connection',
            'version_info', 'version')
 

--- a/aiozmq/__init__.py
+++ b/aiozmq/__init__.py
@@ -5,16 +5,17 @@ from collections import namedtuple
 import zmq
 
 from .core import ZmqEventLoop, ZmqEventLoopPolicy, create_zmq_connection
-from .interface import ZmqTransport, ZmqProtocol
+from .interface import (ZmqTransport, ZmqProtocol, ZmqEventProtocol,
+                        MonitorEvents)
 from .selector import ZmqSelector
 from .stream import (ZmqStream, ZmqStreamProtocol, ZmqStreamClosed,
                      create_zmq_stream)
 
 
 __all__ = ('ZmqSelector', 'ZmqEventLoop', 'ZmqEventLoopPolicy',
-           'ZmqTransport', 'ZmqProtocol',
+           'ZmqTransport', 'ZmqProtocol', 'ZmqEventProtocol',
            'ZmqStream', 'ZmqStreamProtocol', 'create_zmq_stream',
-           'ZmqStreamClosed',
+           'ZmqStreamClosed', 'MonitorEvents',
            'create_zmq_connection',
            'version_info', 'version')
 
@@ -55,5 +56,5 @@ if zmq.zmq_version_info()[0] < 3:  # pragma no cover
 
 # make pyflakes happy
 (ZmqSelector, ZmqEventLoop, ZmqEventLoopPolicy, ZmqTransport, ZmqProtocol,
- ZmqStream, ZmqStreamProtocol, ZmqStreamClosed, create_zmq_stream,
- create_zmq_connection)
+ ZmqEventProtocol, ZmqStream, ZmqStreamProtocol, ZmqStreamClosed,
+ MonitorEvents, create_zmq_stream, create_zmq_connection)

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -24,8 +24,7 @@ else:
     from asyncio.unix_events import SelectorEventLoop, SafeChildWatcher
 
 
-__all__ = ['ZmqEventLoop', 'ZmqEventLoopPolicy', 'create_zmq_connection',
-           '_ZmqEventProtocol']
+__all__ = ['ZmqEventLoop', 'ZmqEventLoopPolicy', 'create_zmq_connection']
 
 
 @asyncio.coroutine
@@ -552,7 +551,7 @@ class _BaseTransport(ZmqTransport):
         if self._monitor is None:
             addr = "inproc://monitor.s-{}".format(self._zmq_sock.FD)
             events = events or zmq.EVENT_ALL
-            _t, self._monitor = yield from create_zmq_connection(
+            _, self._monitor = yield from create_zmq_connection(
                 lambda: _ZmqEventProtocol(self._loop, self._protocol),
                 zmq.PAIR, connect=addr, loop=self._loop)
             # bind must come after connect

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -492,6 +492,12 @@ class _BaseTransport(ZmqTransport):
             raise NotImplementedError("Not supported ZMQ socket type")
         return _EndpointsSet(self._subscriptions)
 
+    def get_monitor_socket(self, events=None, addr=None):
+        return self._zmq_sock.get_monitor_socket(events=events, addr=addr)
+
+    def disable_monitor_socket(self):
+        return self._zmq_sock.disable_monitor()
+
 
 class _ZmqTransportImpl(_BaseTransport):
 

--- a/aiozmq/interface.py
+++ b/aiozmq/interface.py
@@ -1,6 +1,12 @@
+
+import zmq
+
 from asyncio import BaseProtocol, BaseTransport
 
-__all__ = ['ZmqTransport', 'ZmqProtocol']
+from zmq.utils.monitor import parse_monitor_message
+
+
+__all__ = ['ZmqTransport', 'ZmqProtocol', 'ZmqEventProtocol', 'MonitorEvents']
 
 
 class ZmqTransport(BaseTransport):
@@ -185,6 +191,21 @@ class ZmqTransport(BaseTransport):
         """
         raise NotImplementedError
 
+    def get_monitor_socket(self, events=None, addr=None):
+        """ Returns a PAIR socket ready to receive socket events.
+
+        events is a bitmask defining the events to monitor. Default is all
+        events.
+        addr is an optional endpoint string to use for the monitoring socket.
+        """
+        raise NotImplementedError
+
+    def disable_monitor_socket(self):
+        """Shutdown the PAIR socket (created using get_monitor_socket)
+        serving socket events.
+        """
+        raise NotImplementedError
+
 
 class ZmqProtocol(BaseProtocol):
     """Interface for ZeroMQ protocol."""
@@ -194,3 +215,36 @@ class ZmqProtocol(BaseProtocol):
 
         data is the multipart tuple of bytes with at least one item.
         """
+
+MonitorEvents = {zmq.EVENT_ACCEPTED: 'accepted',
+                 zmq.EVENT_ACCEPT_FAILED: 'accept failed',
+                 zmq.EVENT_BIND_FAILED: 'bind failed',
+                 zmq.EVENT_CLOSE_FAILED: 'close failed',
+                 zmq.EVENT_CLOSED: 'closed',
+                 zmq.EVENT_CONNECTED: 'connected',
+                 zmq.EVENT_CONNECT_DELAYED: 'connect delayed',
+                 zmq.EVENT_CONNECT_RETRIED: 'connect retried',
+                 zmq.EVENT_DISCONNECTED: 'disconnected',
+                 zmq.EVENT_LISTENING: 'listening',
+                 zmq.EVENT_MONITOR_STOPPED: 'monitor stopped'}
+
+
+class ZmqEventProtocol(ZmqProtocol):
+    """Interface for ZeroMQ socket events. """
+
+    def event_received(self, event):
+        """Called when a ZeroMQ socket event is received.
+
+        :param event: A dict containing the event description keys `event`,
+          `value`, `description` and `endpoint`.
+        """
+
+    def msg_received(self, data):
+        '''
+        Called from the transport when a ZeroMQ message is received. This
+        protocol only expexts to receive ZMQ socket events.
+        '''
+        evt = parse_monitor_message(data)
+        evt.update({'description': MonitorEvents.get(evt['event'], 'unknown'),
+                    'endpoint': evt['endpoint'].decode()})
+        self.event_received(evt)

--- a/aiozmq/interface.py
+++ b/aiozmq/interface.py
@@ -191,6 +191,8 @@ class ZmqTransport(BaseTransport):
     @asyncio.coroutine
     def enable_monitor(self, events=None):
         """Enables socket monitor events to be reported for this socket.
+        Socket event messages are sent to the ZmqProtocol's event_received
+        method.
 
         This is a coroutine.
 

--- a/aiozmq/interface.py
+++ b/aiozmq/interface.py
@@ -190,10 +190,11 @@ class ZmqTransport(BaseTransport):
 
     @asyncio.coroutine
     def enable_monitor(self, events=None):
-        """Enables socket monitor events to be reported for this socket.
-        Socket events are sent to the ZmqProtocol's event_received method.
+        """Enables socket events to be reported for this socket.
+        Socket events are passed to the protocol's ZmqProtocol's
+        event_received method.
 
-        This is a coroutine.
+        This method is a coroutine.
 
         The socket event monitor capability requires libzmq >= 4 and
         pyzmq >= 14.4.
@@ -204,7 +205,7 @@ class ZmqTransport(BaseTransport):
         For list of available events please see:
         http://api.zeromq.org/4-0:zmq-socket-monitor
 
-        Raise NotImplementedError if libzmq or pyzmq versions do no support
+        Raise NotImplementedError if libzmq or pyzmq versions do not support
         socket monitoring.
         """
         raise NotImplementedError

--- a/aiozmq/interface.py
+++ b/aiozmq/interface.py
@@ -191,8 +191,7 @@ class ZmqTransport(BaseTransport):
     @asyncio.coroutine
     def enable_monitor(self, events=None):
         """Enables socket monitor events to be reported for this socket.
-        Socket event messages are sent to the ZmqProtocol's event_received
-        method.
+        Socket events are sent to the ZmqProtocol's event_received method.
 
         This is a coroutine.
 

--- a/aiozmq/interface.py
+++ b/aiozmq/interface.py
@@ -190,17 +190,26 @@ class ZmqTransport(BaseTransport):
 
     @asyncio.coroutine
     def enable_monitor(self, events=None):
-        """ Returns a PAIR socket ready to receive socket events.
+        """Enables socket monitor events to be reported for this socket.
 
         This is a coroutine.
 
-        events is a bitmask defining the events to monitor. Default is all
-        events.
+        The socket event monitor capability requires libzmq >= 4 and
+        pyzmq >= 14.4.
+
+        events is a bitmask (e.g zmq.EVENT_CONNECTED) defining the events
+        to monitor. Default is all events (i.e. zmq.EVENT_ALL).
+
+        For list of available events please see:
+        http://api.zeromq.org/4-0:zmq-socket-monitor
+
+        Raise NotImplementedError if libzmq or pyzmq versions do no support
+        socket monitoring.
         """
         raise NotImplementedError
 
     def disable_monitor(self):
-        """Stop the socket monitor.
+        """Stop the socket event monitor.
         """
         raise NotImplementedError
 

--- a/aiozmq/interface.py
+++ b/aiozmq/interface.py
@@ -229,6 +229,6 @@ class ZmqProtocol(BaseProtocol):
 
         This method is only called when a socket monitor is enabled.
 
-        :param event: A dict containing the event description keys `event`,
-          `value`, and `endpoint`.
+        :param event: A namedtuple containing 3 items `event`, `value`, and
+          `endpoint`.
         """

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -351,6 +351,28 @@ ZmqTransport
 
       :raise NotImplementedError: the transport is not *SUB*.
 
+   .. method:: enable_monitor(events=None):
+
+      Enables socket events to be reported for this socket. Socket events are
+      passed to the protocol's :meth:`ZmqProtocol.event_received` method.
+
+      The socket event monitor capability requires ``libzmq >= 4`` and
+      ``pyzmq >= 14.4``.
+
+      This method is a coroutine.
+
+      :param events: a bitmask of socket events to watch for. If no value is
+        specified then all events will monitored (i.e. zmq.EVENT_ALL). For list
+        of available events please see:
+        http://api.zeromq.org/4-0:zmq-socket-monitor
+
+      :raise NotImplementedError: if libzmq or pyzmq versions do not support
+        socket monitoring.
+
+   .. method:: disable_monitor():
+
+      Stop the socket event monitor.
+
 
 
 ZmqProtocol
@@ -418,6 +440,15 @@ ZmqProtocol
 
       :param list data: the multipart list of bytes with at least one item.
 
+   .. method:: event_received(event)
+
+      Called when a ZeroMQ socket event is received.
+
+      This method is only called when a socket monitor is enabled.
+
+      :param event: a SocketEvent namedtuple containing 3 items:
+        `event`, `value`, and `endpoint`.
+      :type event: :class:`namedtuple`
 
 Exception policy
 ----------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -89,3 +89,11 @@ Use dynamic RPC lookup
 ----------------------
 
 .. literalinclude:: ../examples/rpc_dynamic.py
+
+
+.. _aiozmq-examples-socket-event-monitor:
+
+Socket event monitor
+--------------------
+
+.. literalinclude:: ../examples/socket_event_monitor.py

--- a/examples/socket_event_monitor.py
+++ b/examples/socket_event_monitor.py
@@ -9,12 +9,25 @@ import aiozmq
 import zmq
 
 
+_events = [i for i in dir(zmq) if i.startswith('EVENT_')]
+ZMQ_EVENTS = {
+    getattr(zmq, name): name.replace(
+        'EVENT_', '').lower().replace('_', ' ')
+              for name in _events if hasattr(zmq, name)}
+
+
+def event_description(event):
+    ''' Return a human readable description of the event '''
+    return ZMQ_EVENTS.get(event, 'unknown')
+
+
 class Protocol(aiozmq.ZmqProtocol):
 
     def __init__(self):
         self.wait_ready = asyncio.Future()
         self.wait_done = asyncio.Future()
         self.wait_closed = asyncio.Future()
+        self.count = 0
 
     def connection_made(self, transport):
         self.transport = transport
@@ -24,79 +37,65 @@ class Protocol(aiozmq.ZmqProtocol):
         self.wait_closed.set_result(exc)
 
     def msg_received(self, data):
-        # This protocol is used by both the Router and Dealer sockets.
-        # Messages received by the router come prefixed with an 'identity'
-        # and hence contain two frames in this simple test protocol.
+        # This protocol is used by both the Router and Dealer sockets in
+        # this example. Router sockets prefix messages with the identity
+        # of the sender and hence contain two frames in this simple test
+        # protocol.
         if len(data) == 2:
             identity, msg = data
-            if msg == b'Hello':
-                self.transport.write([identity, b'World'])
+            assert msg == b'Hello'
+            self.transport.write([identity, b'World'])
         else:
             msg = data[0]
-            if msg == b'World':
+            assert msg == b'World'
+            self.count += 1
+            if self.count >= 4:
                 self.wait_done.set_result(True)
 
-
-class EventProtocol(aiozmq.ZmqEventProtocol):
-
-    def __init__(self):
-        self.wait_ready = asyncio.Future()
-        self.wait_closed = asyncio.Future()
-
-    def connection_made(self, transport):
-        self.transport = transport
-        self.wait_ready.set_result(True)
-
-    def connection_lost(self, exc):
-        self.wait_closed.set_result(exc)
-
     def event_received(self, event):
+        event['description'] = event_description(event['event'])
         print(event)
 
 
 @asyncio.coroutine
 def go():
-    loop = asyncio.get_event_loop()
+
     st, sp = yield from aiozmq.create_zmq_connection(
-        Protocol,
-        zmq.ROUTER,
-        bind='tcp://127.0.0.1:*',
-        loop=loop)
+        Protocol, zmq.ROUTER, bind='tcp://127.0.0.1:*')
     yield from sp.wait_ready
     addr = list(st.bindings())[0]
 
     ct, cp = yield from aiozmq.create_zmq_connection(
-        Protocol,
-        zmq.DEALER,
-        loop=loop)
-
-    # Establish a socket event monitor on the client
-    mon_sock = ct.get_monitor_socket()
-    mt, mp = yield from aiozmq.create_zmq_connection(
-        EventProtocol,
-        zmq.PAIR,
-        zmq_sock=mon_sock,
-        loop=loop)
-    yield from mp.wait_ready
-
-    # Now that the socket event monitor is established lets connect the
-    # client to the server which will trigger some events.
-    yield from ct.connect(addr)
+        Protocol, zmq.DEALER, connect=addr)
     yield from cp.wait_ready
 
-    # Send a message to the server. The server should respond and this
-    # completes the test.
-    ct.write([b'Hello'])
+    # Enable the socket monitor on the client socket. Socket events
+    # are passed to the 'event_received' method on the client protocol.
+    yield from ct.enable_monitor()
+
+    # Trigger some socket events while also sending a message to the
+    # server. When the client protocol receives 4 response it will
+    # fire the wait_done future.
+    for i in range(4):
+        yield from asyncio.sleep(0.1)
+        yield from ct.disconnect(addr)
+        yield from asyncio.sleep(0.1)
+        yield from ct.connect(addr)
+        yield from asyncio.sleep(0.1)
+        ct.write([b'Hello'])
+
     yield from cp.wait_done
 
-    ct.disable_monitor_socket()
+    # The socket monitor can be explicitly disabled if necessary.
+    # ct.disable_monitor()
 
+    # If a socket monitor is left enabled on a socket being closed,
+    # the socket monitor will be closed automatically.
     ct.close()
     yield from cp.wait_closed
+
     st.close()
     yield from sp.wait_closed
-    mt.close()
-    yield from mp.wait_closed
 
 
 def main():
@@ -105,4 +104,7 @@ def main():
 
 
 if __name__ == '__main__':
+    # import logging
+    # logging.basicConfig(level=logging.DEBUG)
+
     main()

--- a/examples/socket_event_monitor.py
+++ b/examples/socket_event_monitor.py
@@ -2,6 +2,9 @@
 '''
 This example demonstrates how to use the ZMQ socket monitor to receive
 socket events.
+
+The socket event monitor capability requires libzmq >= 4 and pyzmq >= 14.4.
+
 '''
 
 import asyncio
@@ -104,5 +107,12 @@ def main():
 if __name__ == '__main__':
     # import logging
     # logging.basicConfig(level=logging.DEBUG)
+
+    if (zmq.zmq_version_info() < (4,) or
+            zmq.pyzmq_version_info() < (14, 4,)):
+        raise NotImplementedError(
+            "Socket monitor requires libzmq >= 4 and pyzmq >= 14.4, "
+            "have libzmq:{}, pyzmq:{}".format(
+                zmq.zmq_version(), zmq.pyzmq_version()))
 
     main()

--- a/examples/socket_event_monitor.py
+++ b/examples/socket_event_monitor.py
@@ -9,11 +9,9 @@ import aiozmq
 import zmq
 
 
-_events = [i for i in dir(zmq) if i.startswith('EVENT_')]
 ZMQ_EVENTS = {
-    getattr(zmq, name): name.replace(
-        'EVENT_', '').lower().replace('_', ' ')
-              for name in _events if hasattr(zmq, name)}
+    getattr(zmq, name): name.replace('EVENT_', '').lower().replace('_', ' ')
+    for name in [i for i in dir(zmq) if i.startswith('EVENT_')]}
 
 
 def event_description(event):

--- a/examples/socket_event_monitor.py
+++ b/examples/socket_event_monitor.py
@@ -54,8 +54,10 @@ class Protocol(aiozmq.ZmqProtocol):
                 self.wait_done.set_result(True)
 
     def event_received(self, event):
-        event['description'] = event_description(event['event'])
-        print(event)
+        print(
+            'event:{}, value:{}, endpoint:{}, description:{}'.format(
+                event.event, event.value, event.endpoint,
+                event_description(event.event)))
 
 
 @asyncio.coroutine

--- a/examples/socket_event_monitor.py
+++ b/examples/socket_event_monitor.py
@@ -1,0 +1,108 @@
+
+'''
+This example demonstrates how to use the ZMQ socket monitor to receive
+socket events.
+'''
+
+import asyncio
+import aiozmq
+import zmq
+
+
+class Protocol(aiozmq.ZmqProtocol):
+
+    def __init__(self):
+        self.wait_ready = asyncio.Future()
+        self.wait_done = asyncio.Future()
+        self.wait_closed = asyncio.Future()
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.wait_ready.set_result(True)
+
+    def connection_lost(self, exc):
+        self.wait_closed.set_result(exc)
+
+    def msg_received(self, data):
+        # This protocol is used by both the Router and Dealer sockets.
+        # Messages received by the router come prefixed with an 'identity'
+        # and hence contain two frames in this simple test protocol.
+        if len(data) == 2:
+            identity, msg = data
+            if msg == b'Hello':
+                self.transport.write([identity, b'World'])
+        else:
+            msg = data[0]
+            if msg == b'World':
+                self.wait_done.set_result(True)
+
+
+class EventProtocol(aiozmq.ZmqEventProtocol):
+
+    def __init__(self):
+        self.wait_ready = asyncio.Future()
+        self.wait_closed = asyncio.Future()
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.wait_ready.set_result(True)
+
+    def connection_lost(self, exc):
+        self.wait_closed.set_result(exc)
+
+    def event_received(self, event):
+        print(event)
+
+
+@asyncio.coroutine
+def go():
+    loop = asyncio.get_event_loop()
+    st, sp = yield from aiozmq.create_zmq_connection(
+        Protocol,
+        zmq.ROUTER,
+        bind='tcp://127.0.0.1:*',
+        loop=loop)
+    yield from sp.wait_ready
+    addr = list(st.bindings())[0]
+
+    ct, cp = yield from aiozmq.create_zmq_connection(
+        Protocol,
+        zmq.DEALER,
+        loop=loop)
+
+    # Establish a socket event monitor on the client
+    mon_sock = ct.get_monitor_socket()
+    mt, mp = yield from aiozmq.create_zmq_connection(
+        EventProtocol,
+        zmq.PAIR,
+        zmq_sock=mon_sock,
+        loop=loop)
+    yield from mp.wait_ready
+
+    # Now that the socket event monitor is established lets connect the
+    # client to the server which will trigger some events.
+    yield from ct.connect(addr)
+    yield from cp.wait_ready
+
+    # Send a message to the server. The server should respond and this
+    # completes the test.
+    ct.write([b'Hello'])
+    yield from cp.wait_done
+
+    ct.disable_monitor_socket()
+
+    ct.close()
+    yield from cp.wait_closed
+    st.close()
+    yield from sp.wait_closed
+    mt.close()
+    yield from mp.wait_closed
+
+
+def main():
+    asyncio.get_event_loop().run_until_complete(go())
+    print("DONE")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -121,11 +121,15 @@ class ZmqSocketMonitorTests(unittest.TestCase):
                 loop=self.loop)
             yield from cp.wait_ready
 
-            with unittest.mock.patch.object(zmq, 'zmq_version_info', return_value=(3, )):
+            with unittest.mock.patch.object(zmq,
+                                            'zmq_version_info',
+                                            return_value=(3, )):
                 with self.assertRaises(NotImplementedError):
                     yield from ct.enable_monitor()
 
-            with unittest.mock.patch.object(zmq, 'pyzmq_version_info', return_value=(14, 3)):
+            with unittest.mock.patch.object(zmq,
+                                            'pyzmq_version_info',
+                                            return_value=(14, 3)):
                 with self.assertRaises(NotImplementedError):
                     yield from ct.enable_monitor()
 

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -80,7 +80,9 @@ class ZmqSocketMonitorTests(unittest.TestCase):
             # Now that the socket event monitor is established, connect
             # the client to the server which will generate some events.
             yield from ct.connect(addr)
+            yield from asyncio.sleep(0.1, loop=self.loop)
             yield from ct.disconnect(addr)
+            yield from asyncio.sleep(0.1, loop=self.loop)
             yield from ct.connect(addr)
 
             # Send a message to the server. The server should respond and

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -1,0 +1,123 @@
+import unittest
+import asyncio
+import aiozmq
+import zmq
+
+from aiozmq._test_util import find_unused_port
+
+
+class Protocol(aiozmq.ZmqProtocol):
+
+    def __init__(self, loop):
+        self.wait_ready = asyncio.Future(loop=loop)
+        self.wait_done = asyncio.Future(loop=loop)
+        self.wait_closed = asyncio.Future(loop=loop)
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.wait_ready.set_result(True)
+
+    def connection_lost(self, exc):
+        self.wait_closed.set_result(exc)
+
+    def msg_received(self, data):
+        # This protocol is used by both the Router and Dealer sockets.
+        # Messages received by the router come prefixed with an 'identity'
+        # and hence contain two frames in this simple test protocol.
+        if len(data) == 2:
+            identity, msg = data
+            if msg == b'Hello':
+                self.transport.write([identity, b'World'])
+        else:
+            msg = data[0]
+            if msg == b'World':
+                self.wait_done.set_result(True)
+
+
+class EventProtocol(aiozmq.ZmqEventProtocol):
+
+    def __init__(self, loop):
+        self.wait_ready = asyncio.Future(loop=loop)
+        self.wait_closed = asyncio.Future(loop=loop)
+        self.received = asyncio.Queue(loop=loop)
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.wait_ready.set_result(True)
+
+    def connection_lost(self, exc):
+        self.wait_closed.set_result(exc)
+
+    def event_received(self, event):
+        self.received.put_nowait(event)
+
+
+class ZmqSocketMonitorTests(unittest.TestCase):
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        self.loop.close()
+        asyncio.set_event_loop(None)
+
+    def test_socket_monitor(self):
+        port = find_unused_port()
+
+        @asyncio.coroutine
+        def go():
+
+            # Create server and bind
+            st, sp = yield from aiozmq.create_zmq_connection(
+                lambda: Protocol(self.loop),
+                zmq.ROUTER,
+                bind='tcp://127.0.0.1:{}'.format(port),
+                loop=self.loop)
+            yield from sp.wait_ready
+            addr = list(st.bindings())[0]
+
+            # Create client but don't connect it yet.
+            ct, cp = yield from aiozmq.create_zmq_connection(
+                lambda: Protocol(self.loop),
+                zmq.DEALER,
+                loop=self.loop)
+
+            # Establish the socket monitor on the client socket
+            mon_sock = ct.get_monitor_socket()
+            mt, mp = yield from aiozmq.create_zmq_connection(
+                lambda: EventProtocol(self.loop),
+                zmq.PAIR,
+                zmq_sock=mon_sock,
+                loop=self.loop)
+            yield from mp.wait_ready
+
+            # Now that the socket event monitor is established, connect
+            # the client to the server which will generate some events.
+            yield from ct.connect(addr)
+            yield from cp.wait_ready
+
+            # Send a message to the server. The server should respond and
+            # this is used to compete the wait_done future.
+            ct.write([b'Hello'])
+            yield from cp.wait_done
+
+            ct.disable_monitor_socket()
+
+            ct.close()
+            yield from cp.wait_closed
+            st.close()
+            yield from sp.wait_closed
+            mt.close()
+            yield from mp.wait_closed
+
+            # Confirm that the events received by the monitor were valid.
+            while not mp.received.empty():
+                event = yield from mp.received.get()
+                self.assertIn(event['event'], aiozmq.MonitorEvents)
+
+        self.loop.run_until_complete(go())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -104,7 +104,7 @@ class ZmqSocketMonitorTests(unittest.TestCase):
             self.assertGreater(cp.events_received.qsize(), 0)
             while not cp.events_received.empty():
                 event = yield from cp.events_received.get()
-                self.assertIn(event['event'], ZMQ_EVENTS)
+                self.assertIn(event.event, ZMQ_EVENTS)
 
         self.loop.run_until_complete(go())
 

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -52,6 +52,9 @@ class ZmqSocketMonitorTests(unittest.TestCase):
         self.loop.close()
         asyncio.set_event_loop(None)
 
+    @unittest.skipIf(
+        zmq.zmq_version_info() < (4,) or zmq.pyzmq_version_info() < (14, 4,),
+        "Socket monitor requires libzmq >= 4 and pyzmq >= 14.4")
     def test_socket_monitor(self):
         port = find_unused_port()
 

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -6,12 +6,17 @@ import zmq
 from aiozmq._test_util import find_unused_port
 
 
+ZMQ_EVENTS = [
+    getattr(zmq, attr) for attr in dir(zmq) if attr.startswith('EVENT_')]
+
+
 class Protocol(aiozmq.ZmqProtocol):
 
     def __init__(self, loop):
         self.wait_ready = asyncio.Future(loop=loop)
         self.wait_done = asyncio.Future(loop=loop)
         self.wait_closed = asyncio.Future(loop=loop)
+        self.events_received = asyncio.Queue(loop=loop)
 
     def connection_made(self, transport):
         self.transport = transport
@@ -33,23 +38,8 @@ class Protocol(aiozmq.ZmqProtocol):
             if msg == b'World':
                 self.wait_done.set_result(True)
 
-
-class EventProtocol(aiozmq.ZmqEventProtocol):
-
-    def __init__(self, loop):
-        self.wait_ready = asyncio.Future(loop=loop)
-        self.wait_closed = asyncio.Future(loop=loop)
-        self.received = asyncio.Queue(loop=loop)
-
-    def connection_made(self, transport):
-        self.transport = transport
-        self.wait_ready.set_result(True)
-
-    def connection_lost(self, exc):
-        self.wait_closed.set_result(exc)
-
     def event_received(self, event):
-        self.received.put_nowait(event)
+        self.events_received.put_nowait(event)
 
 
 class ZmqSocketMonitorTests(unittest.TestCase):
@@ -82,39 +72,34 @@ class ZmqSocketMonitorTests(unittest.TestCase):
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 loop=self.loop)
+            yield from cp.wait_ready
 
-            # Establish the socket monitor on the client socket
-            mon_sock = ct.get_monitor_socket()
-            mt, mp = yield from aiozmq.create_zmq_connection(
-                lambda: EventProtocol(self.loop),
-                zmq.PAIR,
-                zmq_sock=mon_sock,
-                loop=self.loop)
-            yield from mp.wait_ready
+            # Establish an event monitor on the client socket
+            yield from ct.enable_monitor()
 
             # Now that the socket event monitor is established, connect
             # the client to the server which will generate some events.
             yield from ct.connect(addr)
-            yield from cp.wait_ready
+            yield from ct.disconnect(addr)
+            yield from ct.connect(addr)
 
             # Send a message to the server. The server should respond and
             # this is used to compete the wait_done future.
             ct.write([b'Hello'])
             yield from cp.wait_done
 
-            ct.disable_monitor_socket()
+            ct.disable_monitor()
 
             ct.close()
             yield from cp.wait_closed
             st.close()
             yield from sp.wait_closed
-            mt.close()
-            yield from mp.wait_closed
 
             # Confirm that the events received by the monitor were valid.
-            while not mp.received.empty():
-                event = yield from mp.received.get()
-                self.assertIn(event['event'], aiozmq.MonitorEvents)
+            self.assertGreater(cp.events_received.qsize(), 0)
+            while not cp.events_received.empty():
+                event = yield from cp.events_received.get()
+                self.assertIn(event['event'], ZMQ_EVENTS)
 
         self.loop.run_until_complete(go())
 


### PR DESCRIPTION
This pull request adds the ZMQ socket event monitor capability to aiozmq. 

I am using this in my system which uses ephemeral ports. I use it to detect client disconnects, then tear down the socket, use a discovery mechanism to resolve the new endpoint address and finally re-establish the socket. 