### PR TITLE
fix monitor disable test failures

### DIFF
--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -538,7 +538,7 @@ class _BaseTransport(ZmqTransport):
         # performs the actions in the wrong order for use with an event
         # loop.
         # For more information on this issue see:
-        # https://github.com/mkoppanen/php-zmq/issues/130
+        # http://lists.zeromq.org/pipermail/zeromq-dev/2015-July/029181.html
 
         if (zmq.zmq_version_info() < (4,) or
                 zmq.pyzmq_version_info() < (14, 4,)):
@@ -559,6 +559,9 @@ class _BaseTransport(ZmqTransport):
 
     @asyncio.coroutine
     def disable_monitor(self):
+        self._disable_monitor()
+
+    def _disable_monitor(self):
         if self._monitor:
             self._zmq_sock.disable_monitor()
             self._monitor.transport.close()
@@ -631,7 +634,7 @@ class _ZmqTransportImpl(_BaseTransport):
             return
         self._closing = True
         if self._monitor:
-            asyncio.Task(self.disable_monitor(), loop=self._loop)
+            self._disable_monitor()
         if not self._paused:
             self._loop.remove_reader(self._zmq_sock)
         if not self._buffer:
@@ -642,7 +645,7 @@ class _ZmqTransportImpl(_BaseTransport):
         if self._conn_lost:
             return
         if self._monitor:
-            asyncio.Task(self.disable_monitor(), loop=self._loop)
+            self._disable_monitor()
         if self._buffer:
             self._buffer.clear()
             self._buffer_size = 0
@@ -761,7 +764,7 @@ class _ZmqLooplessTransportImpl(_BaseTransport):
             return
         self._closing = True
         if self._monitor:
-            asyncio.Task(self.disable_monitor(), loop=self._loop)
+            self._disable_monitor()
         if not self._buffer:
             self._conn_lost += 1
             if not self._paused:
@@ -772,7 +775,7 @@ class _ZmqLooplessTransportImpl(_BaseTransport):
         if self._conn_lost:
             return
         if self._monitor:
-            asyncio.Task(self.disable_monitor(), loop=self._loop)
+            self._disable_monitor()
         if self._buffer:
             self._buffer.clear()
             self._buffer_size = 0

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -631,7 +631,7 @@ class _ZmqTransportImpl(_BaseTransport):
             return
         self._closing = True
         if self._monitor:
-            self.disable_monitor()
+            asyncio.Task(self.disable_monitor(), loop=self._loop)
         if not self._paused:
             self._loop.remove_reader(self._zmq_sock)
         if not self._buffer:
@@ -642,7 +642,7 @@ class _ZmqTransportImpl(_BaseTransport):
         if self._conn_lost:
             return
         if self._monitor:
-            self.disable_monitor()
+            asyncio.Task(self.disable_monitor(), loop=self._loop)
         if self._buffer:
             self._buffer.clear()
             self._buffer_size = 0
@@ -761,7 +761,7 @@ class _ZmqLooplessTransportImpl(_BaseTransport):
             return
         self._closing = True
         if self._monitor:
-            self.disable_monitor()
+            asyncio.Task(self.disable_monitor(), loop=self._loop)
         if not self._buffer:
             self._conn_lost += 1
             if not self._paused:
@@ -772,7 +772,7 @@ class _ZmqLooplessTransportImpl(_BaseTransport):
         if self._conn_lost:
             return
         if self._monitor:
-            self.disable_monitor()
+            asyncio.Task(self.disable_monitor(), loop=self._loop)
         if self._buffer:
             self._buffer.clear()
             self._buffer_size = 0

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -29,8 +29,8 @@ class Protocol(aiozmq.ZmqProtocol):
     def connection_lost(self, exc):
         assert self.state == 'CONNECTED', self.state
         self.state = 'CLOSED'
-        self.closed.set_result(None)
         self.transport = None
+        self.closed.set_result(None)
 
     def pause_writing(self):
         self.paused = True


### PR DESCRIPTION
This change simply wraps the `disable_monitor` coroutine in a `asyncio.Task` to ensure it is run. 

This change fixes the test failures observed. With the recent change to convert `disable_monitor` to a coroutine some of the monitor related tests no longer pass. However, this is not observed on Travis CI because it uses a `libzmq` and `pyzmq` combination that do not support the socket monitor capability - which in turn results in `aiozmq` monitor tests being skipped.

One strategy that might be worth considering in this area would be to use `asyncio.gather` to accumulate intermediate futures and then call `connection_lost` once the `gather` future fires. This would avoid the potential for race conditions of calling `self._loop.call_soon(self.call_connection_lost, None)` before any prior async functions complete. 