### PR TITLE
Fix tests for Python 3.5

### DIFF
--- a/aiozmq/rpc/base.py
+++ b/aiozmq/rpc/base.py
@@ -9,6 +9,11 @@ from .log import logger
 from .packer import _Packer
 from aiozmq import interface
 
+if hasattr(asyncio, 'ensure_future'):
+    ensure_future = asyncio.ensure_future
+else:  # Deprecated since Python version 3.4.4.
+    ensure_future = asyncio.async
+
 
 class Error(Exception):
     """Base RPC exception"""
@@ -248,11 +253,7 @@ class _BaseServerProtocol(_BaseProtocol):
                     pprint.pformat(args), pprint.pformat(kwargs))  # noqa
 
     def add_pending(self, coro):
-        if hasattr(asyncio, 'ensure_future'):
-            fut = asyncio.ensure_future(coro, loop=self.loop)
-        else:
-            # Deprecated since version 3.4.4.
-            fut = asyncio.async(coro, loop=self.loop)
+        fut = ensure_future(coro, loop=self.loop)
         self.pending_waiters.add(fut)
         return fut
 

--- a/aiozmq/rpc/base.py
+++ b/aiozmq/rpc/base.py
@@ -248,7 +248,11 @@ class _BaseServerProtocol(_BaseProtocol):
                     pprint.pformat(args), pprint.pformat(kwargs))  # noqa
 
     def add_pending(self, coro):
-        fut = asyncio.async(coro, loop=self.loop)
+        if hasattr(asyncio, 'ensure_future'):
+            fut = asyncio.ensure_future(coro, loop=self.loop)
+        else:
+            # Deprecated since version 3.4.4.
+            fut = asyncio.async(coro, loop=self.loop)
         self.pending_waiters.add(fut)
         return fut
 

--- a/tests/rpc_func_annotations.py
+++ b/tests/rpc_func_annotations.py
@@ -1,6 +1,8 @@
 import unittest
 import asyncio
 
+import sys
+
 import aiozmq
 import aiozmq.rpc
 from aiozmq._test_util import find_unused_port
@@ -121,13 +123,21 @@ class FuncAnnotationsTestsMixin:
             with self.assertRaisesRegex(aiozmq.rpc.ParametersError, msg):
                 yield from client.call.single_param(None)
 
-            msg = "TypeError.*'arg' parameter lacking default value"
+            if sys.version_info >= (3, 5):
+                msg = "missing a required argument: 'arg'"
+            else:
+                msg = "TypeError.*'arg' parameter lacking default value"
+
             with self.assertRaisesRegex(aiozmq.rpc.ParametersError, msg):
                 yield from client.call.single_param()
             with self.assertRaisesRegex(aiozmq.rpc.ParametersError, msg):
                 yield from client.call.single_param(bad='value')
 
-            msg = "TypeError.*too many keyword arguments"
+            if sys.version_info >= (3, 5):
+                msg = "got an unexpected keyword argument 'bad'"
+            else:
+                msg = "TypeError.*too many keyword arguments"
+
             with self.assertRaisesRegex(aiozmq.rpc.ParametersError, msg):
                 yield from client.call.single_param(1, bad='value')
 

--- a/tests/rpc_func_annotations.py
+++ b/tests/rpc_func_annotations.py
@@ -124,7 +124,7 @@ class FuncAnnotationsTestsMixin:
                 yield from client.call.single_param(None)
 
             if sys.version_info >= (3, 5):
-                msg = "missing a required argument: 'arg'"
+                msg = "TypeError.*missing a required argument: 'arg'"
             else:
                 msg = "TypeError.*'arg' parameter lacking default value"
 
@@ -134,7 +134,7 @@ class FuncAnnotationsTestsMixin:
                 yield from client.call.single_param(bad='value')
 
             if sys.version_info >= (3, 5):
-                msg = "got an unexpected keyword argument 'bad'"
+                msg = "TypeError.*got an unexpected keyword argument 'bad'"
             else:
                 msg = "TypeError.*too many keyword arguments"
 

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from aiozmq.core import SocketEvent
 from aiozmq._test_util import check_errno, find_unused_port
-
+from aiozmq.rpc.base import ensure_future
 
 ZMQ_EVENTS = [
     getattr(zmq, attr) for attr in dir(zmq) if attr.startswith('EVENT_')]
@@ -230,7 +230,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.read()
 
-            t1 = asyncio.async(f(), loop=self.loop)
+            t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to yield from
             yield from asyncio.sleep(0.001, loop=self.loop)
 
@@ -259,7 +259,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.read()
 
-            t1 = asyncio.async(f(), loop=self.loop)
+            t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to yield from
             yield from asyncio.sleep(0.001, loop=self.loop)
 
@@ -286,7 +286,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.read()
 
-            t1 = asyncio.async(f(), loop=self.loop)
+            t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to yield from
             yield from asyncio.sleep(0.001, loop=self.loop)
 
@@ -310,7 +310,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.read()
 
-            t1 = asyncio.async(f(), loop=self.loop)
+            t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to yield from
             yield from asyncio.sleep(0.001, loop=self.loop)
 
@@ -335,7 +335,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.read()
 
-            t1 = asyncio.async(f(), loop=self.loop)
+            t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to yield from
             yield from asyncio.sleep(0.001, loop=self.loop)
 
@@ -361,7 +361,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.read()
 
-            t1 = asyncio.async(f(), loop=self.loop)
+            t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to yield from
             yield from asyncio.sleep(0.001, loop=self.loop)
 
@@ -447,7 +447,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.drain()
 
-            fut = asyncio.async(f(), loop=self.loop)
+            fut = ensure_future(f(), loop=self.loop)
             yield from asyncio.sleep(0.01, loop=self.loop)
 
             self.assertTrue(s1._protocol._paused)
@@ -492,7 +492,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.drain()
 
-            fut = asyncio.async(f(), loop=self.loop)
+            fut = ensure_future(f(), loop=self.loop)
             yield from asyncio.sleep(0.01, loop=self.loop)
 
             s1.close()
@@ -535,7 +535,7 @@ class ZmqStreamTests(unittest.TestCase):
             def f():
                 yield from s1.drain()
 
-            fut = asyncio.async(f(), loop=self.loop)
+            fut = ensure_future(f(), loop=self.loop)
             yield from asyncio.sleep(0.01, loop=self.loop)
 
             exc = RuntimeError("exception")
@@ -596,7 +596,7 @@ class ZmqStreamTests(unittest.TestCase):
                 loop=self.loop)
 
             events = []
-            t = asyncio.async(f(s2, events), loop=self.loop)
+            t = ensure_future(f(s2, events), loop=self.loop)
 
             yield from s2.transport.enable_monitor()
             yield from s2.transport.connect(addr)


### PR DESCRIPTION
Some error messages changed and `asyncio.async()` has been deprecated and triggers many deprecation warnings, so using `ensure_future()` if present. Perhaps there is a better way to check for ensure_future()?