### PR TITLE
Add missing import to example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,7 +148,7 @@ Example of RPC usage::
         client = yield from aiozmq.rpc.connect_rpc(
             connect='tcp://127.0.0.1:5555')
 
-        ret = yield from client.rpc.remote_func(1, 2)
+        ret = yield from client.call.remote_func(1, 2)
         assert 3 == ret
 
         server.close()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,6 +133,7 @@ Low-level request-reply example::
 
 Example of RPC usage::
 
+    import asyncio
     import aiozmq.rpc
 
     class ServerHandler(aiozmq.rpc.AttrHandler):


### PR DESCRIPTION
The [RPC example](http://aiozmq.readthedocs.io/en/v0.7.1/index.html#getting-started) misses an import.

Fixes #68.