### PR TITLE
remove unnecessary Context creations

### DIFF
--- a/aiozmq/cli/proxy.py
+++ b/aiozmq/cli/proxy.py
@@ -75,7 +75,7 @@ def serve_proxy(options):
         print("No backend socket address specified!", file=sys.stderr)
         sys.exit(1)
 
-    ctx = zmq.Context().instance()
+    ctx = zmq.Context.instance()
 
     front_type, back_type = options.sock_types
 

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -87,7 +87,7 @@ def create_zmq_connection(protocol_factory, zmq_type, *,
 
     try:
         if zmq_sock is None:
-            zmq_sock = zmq.Context().instance().socket(zmq_type)
+            zmq_sock = zmq.Context.instance().socket(zmq_type)
         elif zmq_sock.getsockopt(zmq.TYPE) != zmq_type:
             raise ValueError('Invalid zmq_sock type')
     except zmq.ZMQError as exc:

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -261,7 +261,7 @@ class BaseZmqEventLoopTestsMixin:
         self.loop.run_until_complete(go())
 
     def test_zmq_socket(self):
-        zmq_sock = zmq.Context().instance().socket(zmq.PUB)
+        zmq_sock = zmq.Context.instance().socket(zmq.PUB)
 
         @asyncio.coroutine
         def connect():
@@ -279,7 +279,7 @@ class BaseZmqEventLoopTestsMixin:
         tr.close()
 
     def test_zmq_socket_invalid_type(self):
-        zmq_sock = zmq.Context().instance().socket(zmq.PUB)
+        zmq_sock = zmq.Context.instance().socket(zmq.PUB)
 
         @asyncio.coroutine
         def connect():
@@ -296,7 +296,7 @@ class BaseZmqEventLoopTestsMixin:
         self.assertFalse(zmq_sock.closed)
 
     def test_create_zmq_connection_ZMQError(self):
-        zmq_sock = zmq.Context().instance().socket(zmq.PUB)
+        zmq_sock = zmq.Context.instance().socket(zmq.PUB)
         zmq_sock.close()
 
         @asyncio.coroutine


### PR DESCRIPTION
Obtaining singleton instance of Context trough Context creation is antipattern. It creates and destroys new zmq context just to obtain the singleton one.

https://github.com/zeromq/pyzmq/blob/master/zmq/backend/cython/context.pyx#L44

The patch calls directly the class method `instance()` without creating new Context object.