### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ classifiers = [
     'Operating System :: Microsoft :: Windows',
     'Environment :: Web Environment',
     'Development Status :: 4 - Beta',
+    'Framework :: AsyncIO',
 ]
 
 


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.