### PR TITLE
More convenient create_zmq_stream() and create_zmq_connection()

### DIFF
--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -28,7 +28,7 @@ SocketEvent = namedtuple('SocketEvent', 'event value endpoint')
 
 
 @asyncio.coroutine
-def create_zmq_connection(protocol_factory, zmq_type, *,
+def create_zmq_connection(protocol_factory, zmq_type=None, *,
                           bind=None, connect=None, zmq_sock=None, loop=None,
                           zmq_context=None):
     """A coroutine which creates a ZeroMQ connection endpoint.
@@ -39,7 +39,8 @@ def create_zmq_connection(protocol_factory, zmq_type, *,
     protocol_factory should instantiate object with ZmqProtocol interface.
 
     zmq_type is type of ZeroMQ socket (zmq.REQ, zmq.REP, zmq.PUB, zmq.SUB,
-    zmq.PAIR, zmq.DEALER, zmq.ROUTER, zmq.PULL, zmq.PUSH, etc.)
+    zmq.PAIR, zmq.DEALER, zmq.ROUTER, zmq.PULL, zmq.PUSH, etc.). Can be
+    omitted when existing zmq_sock is specified.
 
     bind is string or iterable of strings that specifies enpoints.
     Every endpoint creates ending for acceptin connections
@@ -92,9 +93,14 @@ def create_zmq_connection(protocol_factory, zmq_type, *,
 
     try:
         if zmq_sock is None:
+            if zmq_type is None:
+                raise ValueError('Either zmq_sock or zmq_type should be '
+                                 'specified')
             if zmq_context is None:
                 zmq_context = zmq.Context.instance()
             zmq_sock = zmq_context.socket(zmq_type)
+        elif zmq_type is None:
+            zmq_type = zmq_sock.type
         elif zmq_sock.getsockopt(zmq.TYPE) != zmq_type:
             raise ValueError('Invalid zmq_sock type')
     except zmq.ZMQError as exc:
@@ -154,7 +160,7 @@ class ZmqEventLoop(SelectorEventLoop):
         super().close()
 
     @asyncio.coroutine
-    def create_zmq_connection(self, protocol_factory, zmq_type, *,
+    def create_zmq_connection(self, protocol_factory, zmq_type=None, *,
                               bind=None, connect=None, zmq_sock=None,
                               zmq_context=None):
         """A coroutine which creates a ZeroMQ connection endpoint.
@@ -164,9 +170,14 @@ class ZmqEventLoop(SelectorEventLoop):
 
         try:
             if zmq_sock is None:
+                if zmq_type is None:
+                    raise ValueError('Either zmq_sock or zmq_type should be '
+                                     'specified')
                 if zmq_context is None:
                     zmq_context = self._zmq_context
                 zmq_sock = zmq_context.socket(zmq_type)
+            elif zmq_type is None:
+                zmq_type = zmq_sock.type
             elif zmq_sock.getsockopt(zmq.TYPE) != zmq_type:
                 raise ValueError('Invalid zmq_sock type')
         except zmq.ZMQError as exc:

--- a/aiozmq/stream.py
+++ b/aiozmq/stream.py
@@ -13,7 +13,7 @@ def create_zmq_stream(zmq_type, *, bind=None, connect=None,
                       loop=None, zmq_sock=None,
                       high_read=None, low_read=None,
                       high_write=None, low_write=None,
-                      events_backlog=100):
+                      events_backlog=100, zmq_context=None):
     """A wrapper for create_zmq_connection() returning a Stream instance.
 
     The arguments are all the usual arguments to create_zmq_connection()
@@ -40,7 +40,8 @@ def create_zmq_stream(zmq_type, *, bind=None, connect=None,
         bind=bind,
         connect=connect,
         zmq_sock=zmq_sock,
-        loop=loop)
+        loop=loop,
+        zmq_context=zmq_context)
     tr.set_write_buffer_limits(high_write, low_write)
     return stream
 

--- a/aiozmq/stream.py
+++ b/aiozmq/stream.py
@@ -9,7 +9,7 @@ class ZmqStreamClosed(Exception):
 
 
 @asyncio.coroutine
-def create_zmq_stream(zmq_type, *, bind=None, connect=None,
+def create_zmq_stream(zmq_type=None, *, bind=None, connect=None,
                       loop=None, zmq_sock=None,
                       high_read=None, low_read=None,
                       high_write=None, low_write=None,


### PR DESCRIPTION
When `create_zmq_stream()` is called with non-zmq event loop, current API doesn't allow the user to specify ZMQ context. If the user wants to use custom ZMQ context, not the one returned by `zmq.Context.instance()` (useful for tests, for example), his only possible choice is to create the socket manually:
```
sock = ctx.socket(zmq.REQ)
```
and call `create_zmq_stream()` with it:
```
stream = create_zmq_stream(zmq.REQ, zmq_sock=sock)
```
Note that it is required to specify `zmq.REQ` twice.

I propose two changes that solve this problem two different ways:
- Add `zmq_context` kwarg:
```
stream = create_zmq_stream(zmq.REQ, zmq_context=ctx)
```
- Make `zmq_type` optional when existing `zmq_sock` is passed to the function:
```
sock = ctx.socket(zmq.REQ)
stream = create_zmq_stream(zmq_sock=sock)
```

There are no tests yet. Are new tests necessary for such trivial change?
