### PR TITLE
More convenient create_zmq_stream() and create_zmq_connection()

### DIFF
--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -29,7 +29,8 @@ SocketEvent = namedtuple('SocketEvent', 'event value endpoint')
 
 @asyncio.coroutine
 def create_zmq_connection(protocol_factory, zmq_type, *,
-                          bind=None, connect=None, zmq_sock=None, loop=None):
+                          bind=None, connect=None, zmq_sock=None, loop=None,
+                          zmq_context=None):
     """A coroutine which creates a ZeroMQ connection endpoint.
 
     The return value is a pair of (transport, protocol),
@@ -74,6 +75,10 @@ def create_zmq_connection(protocol_factory, zmq_type, *,
 
     zmq_sock is a zmq.Socket instance to use preexisting object
     with created transport.
+
+    zmq_context is a zmq.Context object that should be used to create new
+    socket if no zmq_sock is provided. If not specified, default context
+    will be used.
     """
     if loop is None:
         loop = asyncio.get_event_loop()
@@ -82,8 +87,12 @@ def create_zmq_connection(protocol_factory, zmq_type, *,
                                                     zmq_type,
                                                     bind=bind,
                                                     connect=connect,
-                                                    zmq_sock=zmq_sock)
+                                                    zmq_sock=zmq_sock,
+                                                    zmq_context=zmq_context)
         return ret
+
+    if zmq_context is None:
+        zmq_context = zmq.Context.instance()
 
     transport, protocol, _ = yield from _create_zmq_connection(
         protocol_factory=protocol_factory,
@@ -92,7 +101,7 @@ def create_zmq_connection(protocol_factory, zmq_type, *,
         bind=bind,
         connect=connect,
         zmq_sock=zmq_sock,
-        zmq_context=zmq.Context.instance(),
+        zmq_context=zmq_context,
         loop=loop
     )
 
@@ -165,11 +174,15 @@ class ZmqEventLoop(SelectorEventLoop):
 
     @asyncio.coroutine
     def create_zmq_connection(self, protocol_factory, zmq_type, *,
-                              bind=None, connect=None, zmq_sock=None):
+                              bind=None, connect=None, zmq_sock=None,
+                              zmq_context=None):
         """A coroutine which creates a ZeroMQ connection endpoint.
 
         See aiozmq.create_zmq_connection() coroutine for details.
         """
+
+        if zmq_context is None:
+            zmq_context = self._zmq_context
 
         transport, protocol, zmq_sock = yield from _create_zmq_connection(
             protocol_factory=protocol_factory,
@@ -178,7 +191,7 @@ class ZmqEventLoop(SelectorEventLoop):
             bind=bind,
             connect=connect,
             zmq_sock=zmq_sock,
-            zmq_context=self._zmq_context,
+            zmq_context=zmq_context,
             loop=self
         )
 

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -150,7 +150,7 @@ def _create_zmq_connection(protocol_factory, zmq_type, *, transport_factory,
             for endpoint in connect:
                 yield from transport.connect(endpoint)
         return transport, protocol, zmq_sock
-    except OSError:
+    except:
         # don't care if zmq_sock.close can raise exception
         # that should never happen
         zmq_sock.close()

--- a/aiozmq/stream.py
+++ b/aiozmq/stream.py
@@ -13,7 +13,7 @@ def create_zmq_stream(zmq_type, *, bind=None, connect=None,
                       loop=None, zmq_sock=None,
                       high_read=None, low_read=None,
                       high_write=None, low_write=None,
-                      events_backlog=100):
+                      events_backlog=100, zmq_context=None):
     """A wrapper for create_zmq_connection() returning a Stream instance.
 
     The arguments are all the usual arguments to create_zmq_connection()
@@ -40,7 +40,8 @@ def create_zmq_stream(zmq_type, *, bind=None, connect=None,
         bind=bind,
         connect=connect,
         zmq_sock=zmq_sock,
-        loop=loop)
+        loop=loop,
+        zmq_context=zmq_context)
     tr.set_write_buffer_limits(high_write, low_write)
     return stream
 

--- a/aiozmq/stream.py
+++ b/aiozmq/stream.py
@@ -9,7 +9,7 @@ class ZmqStreamClosed(Exception):
 
 
 @asyncio.coroutine
-def create_zmq_stream(zmq_type, *, bind=None, connect=None,
+def create_zmq_stream(zmq_type=None, *, bind=None, connect=None,
                       loop=None, zmq_sock=None,
                       high_read=None, low_read=None,
                       high_write=None, low_write=None,

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -649,6 +649,19 @@ class ZmqStreamTests(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
+    def test_custom_context(self):
+        custom_context = zmq.Context()
+        try:
+            s1 = self.loop.run_until_complete(
+                aiozmq.create_zmq_stream(zmq.DEALER, loop=self.loop,
+                                         zmq_context=custom_context))
+
+            self.assertIs(s1.transport._zmq_sock.context, custom_context)
+            s1.close()
+
+        finally:
+            custom_context.destroy()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -662,6 +662,21 @@ class ZmqStreamTests(unittest.TestCase):
         finally:
             custom_context.destroy()
 
+    def test_omit_zmq_type(self):
+        custom_sock = zmq.Context.instance().socket(zmq.DEALER)
+        s1 = self.loop.run_until_complete(
+            aiozmq.create_zmq_stream(zmq_sock=custom_sock,
+                                     loop=self.loop))
+
+        self.assertEqual(s1.transport.getsockopt(zmq.TYPE), zmq.DEALER)
+        self.assertEqual(s1.transport._zmq_type, zmq.DEALER)
+        s1.close()
+
+    def test_need_sock_or_type(self):
+        with self.assertRaises(ValueError):
+            self.loop.run_until_complete(
+                aiozmq.create_zmq_stream(loop=self.loop))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When `create_zmq_stream()` is called with non-zmq event loop, current API doesn't allow the user to specify ZMQ context. If the user wants to use custom ZMQ context, not the one returned by `zmq.Context.instance()` (useful for tests, for example), his only possible choice is to create the socket manually:
```
sock = ctx.socket(zmq.REQ)
```
and call `create_zmq_stream()` with it:
```
stream = create_zmq_stream(zmq.REQ, zmq_sock=sock)
```
Note that it is required to specify `zmq.REQ` twice.

I propose two changes that solve this problem two different ways:
- Add `zmq_context` kwarg:
```
stream = create_zmq_stream(zmq.REQ, zmq_context=ctx)
```
- Make `zmq_type` optional when existing `zmq_sock` is passed to the function:
```
sock = ctx.socket(zmq.REQ)
stream = create_zmq_stream(zmq_sock=sock)
```
