### PR TITLE
support 3.6 and drop 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
 language: python
 
 python:
-  - "3.4"
   - "3.5"
+  - "3.6"
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libzmq3-dev
 
 install:
-  - pip install pip setuptools wheel
+  - pip install --upgrade pip setuptools wheel
   - python setup.py install
   - test $USE_MSGPACK == 1 && pip install msgpack-python || true
-  - pip install pyflakes
-  - pip install pycodestyle
-  - pip install docutils
-  - pip install codecov
+  - pip install pyflakes pycodestyle docutils codecov
 
 script:
   - python -c "import zmq; print('ZMQ version:', zmq.zmq_version())"

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ asyncio integration with ZeroMQ
 
 asyncio (PEP 3156) support for ZeroMQ.
 
-.. image:: https://travis-ci.org/aio-libs/aiozmq.svg?branch=master
-   :target: https://travis-ci.org/aio-libs/aiozmq
+.. image:: https://travis-ci.com/aio-libs/aiozmq.svg?branch=master
+   :target: https://travis-ci.com/aio-libs/aiozmq
 
 The difference between ``aiozmq`` and vanilla ``pyzmq`` (``zmq.asyncio``).
 
@@ -105,7 +105,7 @@ For details see https://github.com/zeromq/pyzmq/issues/894
 Requirements
 ------------
 
-* Python_ 3.4+
+* Python_ 3.5+
 * pyzmq_ 13.1+
 * optional submodule ``aiozmq.rpc`` requires msgpack-python_ 0.4+
 

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,6 @@ from setuptools import setup, find_packages
 
 install_requires = ['pyzmq>=13.1']
 
-PY_VER = sys.version_info
-
-if PY_VER >= (3, 4):
-    pass
-elif PY_VER >= (3, 3):
-    install_requires.append('asyncio')
-else:
-    raise RuntimeError("aiozmq doesn't support Python earlier than 3.3")
-
 tests_require = install_requires + ['msgpack>=0.5.0']
 
 extras_require = {'rpc': ['msgpack>=0.5.0']}
@@ -40,9 +31,8 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Intended Audience :: Developers',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Operating System :: POSIX',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 from setuptools import setup, find_packages
 
 
@@ -8,6 +9,10 @@ install_requires = ['pyzmq>=13.1']
 tests_require = install_requires + ['msgpack>=0.5.0']
 
 extras_require = {'rpc': ['msgpack>=0.5.0']}
+
+
+if sys.version_info < (3, 5):
+    raise RuntimeError("aiozmq requires Python 3.5 or higher")
 
 
 def read(f):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
I'd like to support 3.7 too but there are some test failures that are nontrivial
to fix, so I'll do that separately.