### PR TITLE
Remove usage of asyncio.test_utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - pip install --upgrade pip setuptools wheel
   - python setup.py install
-  - test $USE_MSGPACK == 1 && pip install msgpack-python || true
+  - test $USE_MSGPACK == 1 && pip install msgpack || true
   - pip install pyflakes pycodestyle docutils codecov
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,9 @@ Documentation
 
 See http://aiozmq.readthedocs.org
 
-Simple high-level client-server RPC example::
+Simple high-level client-server RPC example:
+
+.. code-block:: python
 
     import asyncio
     import aiozmq.rpc
@@ -55,7 +57,9 @@ Simple high-level client-server RPC example::
 
     asyncio.get_event_loop().run_until_complete(go())
 
-Low-level request-reply example::
+Low-level request-reply example:
+
+.. code-block:: python
 
     import asyncio
     import aiozmq

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ E.g. if you build a web server for handling at least thousands of
 parallel web requests (1000-5000) `pyzmq` internal Poller will be slow.
 
 `aiozmq` works with epoll natively, it doesn't need custom loop
-implementation and cooperates pretty weel with `uvloop` for example.
+implementation and cooperates pretty well with `uvloop` for example.
 
 For details see https://github.com/zeromq/pyzmq/issues/894
 

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -7,7 +7,8 @@ import threading
 import weakref
 import zmq
 
-from collections import deque, Iterable, namedtuple
+from collections import deque, namedtuple
+from collections.abc import Iterable
 
 from .interface import ZmqTransport, ZmqProtocol
 from .log import logger

--- a/aiozmq/rpc/__init__.py
+++ b/aiozmq/rpc/__init__.py
@@ -35,7 +35,7 @@ _MSGPACK_VERSION = (0, 4, 0)
 _MSGPACK_VERSION_STR = '.'.join(map(str, _MSGPACK_VERSION))
 
 if msgpack_version < _MSGPACK_VERSION:  # pragma: no cover
-    raise ImportError("aiozmq.rpc requires msgpack-python package"
+    raise ImportError("aiozmq.rpc requires msgpack package"
                       " (version >= {})".format(_MSGPACK_VERSION_STR))
 
 

--- a/aiozmq/rpc/pubsub.py
+++ b/aiozmq/rpc/pubsub.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import Iterable
+from collections.abc import Iterable
 from functools import partial
 
 import zmq

--- a/aiozmq/selector.py
+++ b/aiozmq/selector.py
@@ -1,6 +1,6 @@
 """ZMQ pooler for asyncio."""
 import math
-from collections import Mapping
+from collections.abc import Mapping
 from errno import EINTR
 
 from zmq import (ZMQError, POLLIN, POLLOUT, POLLERR,

--- a/aiozmq/util.py
+++ b/aiozmq/util.py
@@ -1,4 +1,4 @@
-from collections import Set
+from collections.abc import Set
 
 
 class _EndpointsSet(Set):

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -65,8 +65,8 @@ Glossary
 
       Fast and compact binary serialization format.
 
-      See http://msgpack.org/ for standard description.
-      https://pypi.python.org/pypi/msgpack-python/ is Python implementation.
+      See http://msgpack.org/ for the description of the standard.
+      https://pypi.python.org/pypi/msgpack/ is the Python implementation.
 
    pyzmq
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,9 +50,9 @@ Also probably you want to use :mod:`aiozmq.rpc`.
 .. _aiozmq-install-msgpack:
 
 RPC module is **optional** and requires :term:`msgpack`. You can
-install *msgpack-python* by executing::
+install *msgpack* by executing::
 
-  pip3 install msgpack-python
+  pip3 install msgpack
 
 .. note::
 

--- a/docs/rpc.rst
+++ b/docs/rpc.rst
@@ -36,10 +36,10 @@ The :mod:`aiozmq.rpc` supports three pairs of communications:
    * :ref:`aiozmq-rpc-pushpull`
    * :ref:`aiozmq-rpc-pubsub`
 
-.. warning:: :mod:`aiozmq.rpc` module is **optional** and requires
-   :term:`msgpack`. You can install *msgpack-python* by executing::
+.. warning:: The :mod:`aiozmq.rpc` module is **optional** and requires
+   :term:`msgpack`. You can install *msgpack* by executing::
 
-       pip3 install msgpack-python\>=0.4.0
+       pip3 install msgpack
 
 
 .. _aiozmq-rpc-rpc:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['pyzmq>=13.1']
+install_requires = ['pyzmq>=13.1,<17.1.2']
 
 tests_require = install_requires + ['msgpack>=0.5.0']
 

--- a/tests/rpc_pipeline_test.py
+++ b/tests/rpc_pipeline_test.py
@@ -5,7 +5,6 @@ import aiozmq.rpc
 import logging
 
 from unittest import mock
-from asyncio.test_utils import run_briefly
 from aiozmq._test_util import log_hook, RpcMixin
 
 
@@ -185,8 +184,13 @@ class PipelineTestsMixin(RpcMixin):
                 self.assertEqual(('suspicious',), ret.args)
                 self.assertIsNone(ret.exc_info)
 
+        @asyncio.coroutine
+        def dummy():
+            if False:
+                yield
+
         self.loop.run_until_complete(communicate())
-        run_briefly(self.loop)
+        self.loop.run_until_complete(dummy())
 
     def test_call_closed_pipeline(self):
         client, server = self.make_pipeline_pair()

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -84,10 +84,12 @@ class TestLoop(asyncio.base_events.BaseEventLoop):
         handle = self.readers[fd]
         if handle._callback != callback:
             raise AssertionError(
-                'unexpected callback: {handle._callback} != {callback}'.format(handle=handle, callback=callback))
+                'unexpected callback: {handle._callback} != {callback}'.format(
+                    handle=handle, callback=callback))
         if handle._args != args:
             raise AssertionError(
-                'unexpected callback args: {handle._args} != {args}'.format(handle=handle, args=args))
+                'unexpected callback args: {handle._args} != {args}'.format(
+                    handle=handle, args=args))
 
     def assert_no_reader(self, fd):
         if fd in self.readers:

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -5,6 +5,7 @@ import collections
 import zmq
 import aiozmq
 import errno
+import selectors
 import weakref
 
 from collections import deque
@@ -35,13 +36,13 @@ def make_test_protocol(base):
     return type('TestProtocol', (base,) + base.__bases__, dct)()
 
 
-class TestSelector(asyncio.selectors.BaseSelector):
+class TestSelector(selectors.BaseSelector):
 
     def __init__(self):
         self.keys = {}
 
     def register(self, fileobj, events, data=None):
-        key = asyncio.selectors.SelectorKey(fileobj, 0, events, data)
+        key = selectors.SelectorKey(fileobj, 0, events, data)
         self.keys[fileobj] = key
         return key
 

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -94,7 +94,7 @@ class TestLoop(asyncio.base_events.BaseEventLoop):
 
     def assert_no_reader(self, fd):
         if fd in self.readers:
-            raise AssertionError(f'fd {fd} is registered')
+            raise AssertionError('fd {fd} is registered'.format(fd=fd))
 
     def _add_writer(self, fd, callback, *args):
         self.writers[fd] = asyncio.events.Handle(callback, args, self)

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -116,6 +116,8 @@ class BaseZmqEventLoopTestsMixin:
             return tr2, pr2
 
         tr2, pr2 = self.loop.run_until_complete(connect_rep())
+        # Without this, this test hangs for some reason.
+        tr2._zmq_sock.getsockopt(zmq.EVENTS)
 
         @asyncio.coroutine
         def communicate():


### PR DESCRIPTION
In Python 3.7, `asyncio.test_utils` was renamed to make it clear that it is private (python/cpython#4785). Unfortunately, aiozmq relies on it fairly extensively. In this PR, I copy over the implementation of `TestLoop` from current CPython master in the absence of a better option.