### PR TITLE
Fix: DeprecationWarning in Python3.7

### DIFF
--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -7,7 +7,8 @@ import threading
 import weakref
 import zmq
 
-from collections import deque, Iterable, namedtuple
+from collections import deque, namedtuple
+from collections.abc import Iterable
 
 from .interface import ZmqTransport, ZmqProtocol
 from .log import logger

--- a/aiozmq/rpc/pubsub.py
+++ b/aiozmq/rpc/pubsub.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import Iterable
+from collections.abc import Iterable
 from functools import partial
 
 import zmq

--- a/aiozmq/selector.py
+++ b/aiozmq/selector.py
@@ -1,6 +1,6 @@
 """ZMQ pooler for asyncio."""
 import math
-from collections import Mapping
+from collections.abc import Mapping
 from errno import EINTR
 
 from zmq import (ZMQError, POLLIN, POLLOUT, POLLERR,

--- a/aiozmq/util.py
+++ b/aiozmq/util.py
@@ -1,4 +1,4 @@
-from collections import Set
+from collections.abc import Set
 
 
 class _EndpointsSet(Set):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['pyzmq>=13.1']
+install_requires = ['pyzmq>=13.1,<17.1.2']
 
 tests_require = install_requires + ['msgpack>=0.5.0']
 


### PR DESCRIPTION
Avoid some DeprecationWarnings when using Python 3.7

Ref: https://github.com/python/cpython/pull/5460
Ref: https://bugs.python.org/issue25988

Note: the latest version of `pyzmq` breaks the build. It's not related to this change. 