### PR TITLE
Use msgpack instead of msgpack-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - pip install --upgrade pip setuptools wheel
   - python setup.py install
-  - test $USE_MSGPACK == 1 && pip install msgpack-python || true
+  - test $USE_MSGPACK == 1 && pip install msgpack || true
   - pip install pyflakes pycodestyle docutils codecov
 
 script:

--- a/aiozmq/rpc/__init__.py
+++ b/aiozmq/rpc/__init__.py
@@ -35,7 +35,7 @@ _MSGPACK_VERSION = (0, 4, 0)
 _MSGPACK_VERSION_STR = '.'.join(map(str, _MSGPACK_VERSION))
 
 if msgpack_version < _MSGPACK_VERSION:  # pragma: no cover
-    raise ImportError("aiozmq.rpc requires msgpack-python package"
+    raise ImportError("aiozmq.rpc requires msgpack package"
                       " (version >= {})".format(_MSGPACK_VERSION_STR))
 
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -65,8 +65,8 @@ Glossary
 
       Fast and compact binary serialization format.
 
-      See http://msgpack.org/ for standard description.
-      https://pypi.python.org/pypi/msgpack-python/ is Python implementation.
+      See http://msgpack.org/ for the description of the standard.
+      https://pypi.python.org/pypi/msgpack/ is the Python implementation.
 
    pyzmq
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,9 +50,9 @@ Also probably you want to use :mod:`aiozmq.rpc`.
 .. _aiozmq-install-msgpack:
 
 RPC module is **optional** and requires :term:`msgpack`. You can
-install *msgpack-python* by executing::
+install *msgpack* by executing::
 
-  pip3 install msgpack-python
+  pip3 install msgpack
 
 .. note::
 

--- a/docs/rpc.rst
+++ b/docs/rpc.rst
@@ -36,10 +36,10 @@ The :mod:`aiozmq.rpc` supports three pairs of communications:
    * :ref:`aiozmq-rpc-pushpull`
    * :ref:`aiozmq-rpc-pubsub`
 
-.. warning:: :mod:`aiozmq.rpc` module is **optional** and requires
-   :term:`msgpack`. You can install *msgpack-python* by executing::
+.. warning:: The :mod:`aiozmq.rpc` module is **optional** and requires
+   :term:`msgpack`. You can install *msgpack* by executing::
 
-       pip3 install msgpack-python\>=0.4.0
+       pip3 install msgpack
 
 
 .. _aiozmq-rpc-rpc:


### PR DESCRIPTION
Follow-up to https://github.com/aio-libs/aiozmq/pull/148 - mainly to see if builds get stuck here, too.

But it should also be replaced throughout the codebase anyway.