### PR TITLE
Fix failing test for 3.7, extend job matrix on Travis with 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 before_install:
   - sudo apt-get update -qq
@@ -40,12 +42,7 @@ cache: apt
 
 jobs:
   fast_finish: true
-  allow_failures:
-  - python: 3.7
   include:
-  - python: 3.7
-    dist: xenial
-    sudo: required
   - stage: Deploy to PYPI
     python: 3.6
     script: skip

--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -654,7 +654,10 @@ class _ZmqTransportImpl(_BaseTransport):
         if not self._closing:
             self._closing = True
             if not self._paused:
-                self._loop.remove_reader(self._zmq_sock)
+                if self._zmq_sock.closed:
+                    self._loop._remove_reader(self._zmq_sock)
+                else:
+                    self._loop.remove_reader(self._zmq_sock)
         self._conn_lost += 1
         self._loop.call_soon(self._call_connection_lost, exc)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['pyzmq>=13.1,<17.1.2']
+install_requires = ['pyzmq>=13.1,!=17.1.2']
 
 tests_require = install_requires + ['msgpack>=0.5.0']
 


### PR DESCRIPTION
## What do these changes do?

This change fixes a remaining test failing with Python 3.7, in particular adapting to changes in https://github.com/python/cpython/pull/4365 same way the [`SelectorTransport` does](https://github.com/python/cpython/blob/master/Lib/asyncio/selector_events.py#L719). In addition, it extends the job matrix on travis-ci.com to test against Python 3.8 and combinations of `msgpack` extra installed and debug mode for `asyncio` turned on. Last change is the `pyzmq` version constraint fixed to allow the recent `pyzmq` version to be installed.

## Are there changes in behavior for the user?

No

## Related issue number

Closes #132.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] ~~Documentation reflects the changes~~ no changes in behaviour
- [ ] ~~Add a new news fragment into the `CHANGES` folder~~ `towncrier` not set up