### PR TITLE
Remove some usage of deprecated loop= parameters

### DIFF
--- a/aiozmq/core.py
+++ b/aiozmq/core.py
@@ -93,7 +93,7 @@ async def create_zmq_connection(
         raise OSError(exc.errno, exc.strerror) from exc
 
     protocol = protocol_factory()
-    waiter = asyncio.Future(loop=loop)
+    waiter = asyncio.Future()
     transport = _ZmqLooplessTransportImpl(loop, zmq_type, zmq_sock, protocol, waiter)
     await waiter
 
@@ -204,8 +204,8 @@ class _ZmqEventProtocol(ZmqProtocol):
 
     def __init__(self, loop, main_protocol):
         self._protocol = main_protocol
-        self.wait_ready = asyncio.Future(loop=loop)
-        self.wait_closed = asyncio.Future(loop=loop)
+        self.wait_ready = asyncio.Future()
+        self.wait_closed = asyncio.Future()
 
     def connection_made(self, transport):
         self.transport = transport

--- a/aiozmq/rpc/base.py
+++ b/aiozmq/rpc/base.py
@@ -260,7 +260,7 @@ class _BaseServerProtocol(_BaseProtocol):
                 )  # noqa
 
     def add_pending(self, coro):
-        fut = ensure_future(coro, loop=self.loop)
+        fut = ensure_future(coro)
         self.pending_waiters.add(fut)
         return fut
 

--- a/aiozmq/rpc/pipeline.py
+++ b/aiozmq/rpc/pipeline.py
@@ -110,7 +110,7 @@ class _ClientProtocol(_BaseProtocol):
         bargs = self.packer.packb(args)
         bkwargs = self.packer.packb(kwargs)
         self.transport.write([bname, bargs, bkwargs])
-        fut = asyncio.Future(loop=self.loop)
+        fut = asyncio.Future()
         fut.set_result(None)
         return fut
 
@@ -140,13 +140,13 @@ class _ServerProtocol(_BaseServerProtocol):
             func = self.dispatch(name)
             args, kwargs, ret_ann = self.check_args(func, args, kwargs)
         except (NotFoundError, ParametersError) as exc:
-            fut = asyncio.Future(loop=self.loop)
+            fut = asyncio.Future()
             fut.set_exception(exc)
         else:
             if asyncio.iscoroutinefunction(func):
                 fut = self.add_pending(func(*args, **kwargs))
             else:
-                fut = asyncio.Future(loop=self.loop)
+                fut = asyncio.Future()
                 try:
                     fut.set_result(func(*args, **kwargs))
                 except Exception as exc:

--- a/aiozmq/rpc/pubsub.py
+++ b/aiozmq/rpc/pubsub.py
@@ -134,7 +134,7 @@ class _ClientProtocol(_BaseProtocol):
         bargs = self.packer.packb(args)
         bkwargs = self.packer.packb(kwargs)
         self.transport.write([btopic, bname, bargs, bkwargs])
-        fut = asyncio.Future(loop=self.loop)
+        fut = asyncio.Future()
         fut.set_result(None)
         return fut
 
@@ -213,13 +213,13 @@ class _ServerProtocol(_BaseServerProtocol):
             func = self.dispatch(name)
             args, kwargs, ret_ann = self.check_args(func, args, kwargs)
         except (NotFoundError, ParametersError) as exc:
-            fut = asyncio.Future(loop=self.loop)
+            fut = asyncio.Future()
             fut.set_exception(exc)
         else:
             if asyncio.iscoroutinefunction(func):
                 fut = self.add_pending(func(*args, **kwargs))
             else:
-                fut = asyncio.Future(loop=self.loop)
+                fut = asyncio.Future()
                 try:
                     fut.set_result(func(*args, **kwargs))
                 except Exception as exc:

--- a/aiozmq/rpc/rpc.py
+++ b/aiozmq/rpc/rpc.py
@@ -216,7 +216,7 @@ class _ClientProtocol(_BaseProtocol):
         bkwargs = self.packer.packb(kwargs)
         header, req_id = self._new_id()
         assert req_id not in self.calls, (req_id, self.calls)
-        fut = asyncio.Future(loop=self.loop)
+        fut = asyncio.Future()
         self.calls[req_id] = fut
         self.transport.write([header, bname, bargs, bkwargs])
         return fut
@@ -290,7 +290,7 @@ class _ServerProtocol(_BaseServerProtocol):
             func = self.dispatch(name)
             args, kwargs, ret_ann = self.check_args(func, args, kwargs)
         except (NotFoundError, ParametersError) as exc:
-            fut = asyncio.Future(loop=self.loop)
+            fut = asyncio.Future()
             fut.add_done_callback(
                 partial(
                     self.process_call_result,
@@ -306,7 +306,7 @@ class _ServerProtocol(_BaseServerProtocol):
             if asyncio.iscoroutinefunction(func):
                 fut = self.add_pending(func(*args, **kwargs))
             else:
-                fut = asyncio.Future(loop=self.loop)
+                fut = asyncio.Future()
                 try:
                     fut.set_result(func(*args, **kwargs))
                 except Exception as exc:

--- a/benchmarks/simple.py
+++ b/benchmarks/simple.py
@@ -171,8 +171,8 @@ def _test_core_aiozmq(count, loop):
     print(".", end="", flush=True)
 
     async def go():
-        router_closed = asyncio.Future(loop=loop)
-        dealer_closed = asyncio.Future(loop=loop)
+        router_closed = asyncio.Future()
+        dealer_closed = asyncio.Future()
         router, _ = await aiozmq.create_zmq_connection(
             lambda: ZmqRouterProtocol(router_closed),
             zmq.ROUTER,
@@ -211,8 +211,8 @@ def test_core_aiozmq_legacy(count):
     loop = aiozmq.ZmqEventLoop()
 
     async def go():
-        router_closed = asyncio.Future(loop=loop)
-        dealer_closed = asyncio.Future(loop=loop)
+        router_closed = asyncio.Future()
+        dealer_closed = asyncio.Future()
         router, _ = await aiozmq.create_zmq_connection(
             lambda: ZmqRouterProtocol(router_closed),
             zmq.ROUTER,

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -8,6 +8,7 @@ from aiozmq.core import SocketEvent
 class ZmqTransportTests(unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
     def tearDown(self):
         self.loop.close()
@@ -53,6 +54,7 @@ class ZmqProtocolTests(unittest.TestCase):
 class ZmqEventProtocolTests(unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
     def tearDown(self):
         self.loop.close()

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -65,7 +65,6 @@ class ZmqSocketMonitorTests(unittest.TestCase):
                 lambda: Protocol(self.loop),
                 zmq.ROUTER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await sp.wait_ready
             addr = list(st.bindings())[0]

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -71,7 +71,7 @@ class ZmqSocketMonitorTests(unittest.TestCase):
 
             # Create client but don't connect it yet.
             ct, cp = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.DEALER, loop=self.loop
+                lambda: Protocol(self.loop), zmq.DEALER
             )
             await cp.wait_ready
 
@@ -110,7 +110,7 @@ class ZmqSocketMonitorTests(unittest.TestCase):
         async def go():
 
             ct, cp = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.DEALER, loop=self.loop
+                lambda: Protocol(self.loop), zmq.DEALER
             )
             await cp.wait_ready
 
@@ -137,7 +137,7 @@ class ZmqSocketMonitorTests(unittest.TestCase):
         async def go():
 
             ct, cp = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.DEALER, loop=self.loop
+                lambda: Protocol(self.loop), zmq.DEALER
             )
             await cp.wait_ready
 

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -13,10 +13,10 @@ ZMQ_EVENTS = [getattr(zmq, attr) for attr in dir(zmq) if attr.startswith("EVENT_
 
 class Protocol(aiozmq.ZmqProtocol):
     def __init__(self, loop):
-        self.wait_ready = asyncio.Future(loop=loop)
-        self.wait_done = asyncio.Future(loop=loop)
-        self.wait_closed = asyncio.Future(loop=loop)
-        self.events_received = asyncio.Queue(loop=loop)
+        self.wait_ready = asyncio.Future()
+        self.wait_done = asyncio.Future()
+        self.wait_closed = asyncio.Future()
+        self.events_received = asyncio.Queue()
 
     def connection_made(self, transport):
         self.transport = transport

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -82,9 +82,9 @@ class ZmqSocketMonitorTests(unittest.TestCase):
             # Now that the socket event monitor is established, connect
             # the client to the server which will generate some events.
             await ct.connect(addr)
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
             await ct.disconnect(addr)
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
             await ct.connect(addr)
 
             # Send a message to the server. The server should respond and

--- a/tests/rpc_func_annotations.py
+++ b/tests/rpc_func_annotations.py
@@ -51,11 +51,11 @@ class FuncAnnotationsTestsMixin:
 
         async def create():
             server = await aiozmq.rpc.serve_rpc(
-                MyHandler(), bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                MyHandler(), bind="tcp://127.0.0.1:{}".format(port)
             )
 
             client = await aiozmq.rpc.connect_rpc(
-                connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                connect="tcp://127.0.0.1:{}".format(port)
             )
             return client, server
 

--- a/tests/rpc_namespace_test.py
+++ b/tests/rpc_namespace_test.py
@@ -26,10 +26,10 @@ class RpcNamespaceTestsMixin:
 
         async def create():
             server = await aiozmq.rpc.serve_rpc(
-                RootHandler(), bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                RootHandler(), bind="tcp://127.0.0.1:{}".format(port)
             )
             client = await aiozmq.rpc.connect_rpc(
-                connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                connect="tcp://127.0.0.1:{}".format(port)
             )
             return client, server
 

--- a/tests/rpc_pipeline_test.py
+++ b/tests/rpc_pipeline_test.py
@@ -36,7 +36,7 @@ class MyHandler(aiozmq.rpc.AttrHandler):
 
     @aiozmq.rpc.method
     async def fut(self):
-        f = asyncio.Future(loop=self.loop)
+        f = asyncio.Future()
         await self.queue.put(f)
         await f
 
@@ -211,10 +211,10 @@ class PipelineTestsMixin(RpcMixin):
 class LoopPipelineTests(unittest.TestCase, PipelineTestsMixin):
     def setUp(self):
         self.loop = aiozmq.ZmqEventLoop()
-        asyncio.set_event_loop(None)
+        asyncio.set_event_loop(self.loop)
         self.client = self.server = None
-        self.queue = asyncio.Queue(loop=self.loop)
-        self.err_queue = asyncio.Queue(loop=self.loop)
+        self.queue = asyncio.Queue()
+        self.err_queue = asyncio.Queue()
         self.loop.set_exception_handler(self.exception_handler)
 
     def tearDown(self):
@@ -228,10 +228,10 @@ class LoopPipelineTests(unittest.TestCase, PipelineTestsMixin):
 class LooplessPipelineTests(unittest.TestCase, PipelineTestsMixin):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
+        asyncio.set_event_loop(self.loop)
         self.client = self.server = None
-        self.queue = asyncio.Queue(loop=self.loop)
-        self.err_queue = asyncio.Queue(loop=self.loop)
+        self.queue = asyncio.Queue()
+        self.err_queue = asyncio.Queue()
         self.loop.set_exception_handler(self.exception_handler)
 
     def tearDown(self):

--- a/tests/rpc_pipeline_test.py
+++ b/tests/rpc_pipeline_test.py
@@ -69,7 +69,7 @@ class PipelineTestsMixin(RpcMixin):
             )
             connect = next(iter(server.transport.bindings()))
             client = await aiozmq.rpc.connect_pipeline(
-                connect=connect, loop=self.loop if use_loop else None
+                connect=connect if use_loop else None
             )
             return client, server
 

--- a/tests/rpc_pipeline_test.py
+++ b/tests/rpc_pipeline_test.py
@@ -201,7 +201,7 @@ class PipelineTestsMixin(RpcMixin):
             self.assertIsInstance(task, asyncio.Task)
             server.close()
             await server.wait_closed()
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
             self.assertEqual(0, len(server._proto.pending_waiters))
             fut.cancel()
 

--- a/tests/rpc_pubsub_test.py
+++ b/tests/rpc_pubsub_test.py
@@ -334,7 +334,7 @@ class PubSubTestsMixin(RpcMixin):
             self.assertIsInstance(task, asyncio.Task)
             server.close()
             await server.wait_closed()
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
             self.assertEqual(0, len(server._proto.pending_waiters))
             fut.cancel()
 

--- a/tests/rpc_pubsub_test.py
+++ b/tests/rpc_pubsub_test.py
@@ -225,7 +225,6 @@ class PubSubTestsMixin(RpcMixin):
             server = await aiozmq.rpc.serve_pubsub(
                 MyHandler(self.queue, self.loop),
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             self.assertRaises(TypeError, server.subscribe, 123)
 
@@ -236,7 +235,6 @@ class PubSubTestsMixin(RpcMixin):
             server = await aiozmq.rpc.serve_pubsub(
                 MyHandler(self.queue, self.loop),
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             self.assertRaises(TypeError, server.subscribe, 123)
 
@@ -280,7 +278,6 @@ class PubSubTestsMixin(RpcMixin):
                 await aiozmq.rpc.serve_pubsub(
                     {},
                     bind="tcp://127.0.0.1:{}".format(port),
-                    loop=self.loop,
                     subscribe=123,
                 )
 

--- a/tests/rpc_pubsub_test.py
+++ b/tests/rpc_pubsub_test.py
@@ -37,7 +37,7 @@ class MyHandler(aiozmq.rpc.AttrHandler):
 
     @aiozmq.rpc.method
     async def fut(self):
-        f = asyncio.Future(loop=self.loop)
+        f = asyncio.Future()
         await self.queue.put(f)
         await f
 
@@ -344,10 +344,10 @@ class PubSubTestsMixin(RpcMixin):
 class LoopPubSubTests(unittest.TestCase, PubSubTestsMixin):
     def setUp(self):
         self.loop = aiozmq.ZmqEventLoop()
-        asyncio.set_event_loop(None)
+        asyncio.set_event_loop(self.loop)
         self.client = self.server = None
-        self.queue = asyncio.Queue(loop=self.loop)
-        self.err_queue = asyncio.Queue(loop=self.loop)
+        self.queue = asyncio.Queue()
+        self.err_queue = asyncio.Queue()
 
     def tearDown(self):
         self.close_service(self.client)
@@ -360,10 +360,10 @@ class LoopPubSubTests(unittest.TestCase, PubSubTestsMixin):
 class LooplessPubSubTests(unittest.TestCase, PubSubTestsMixin):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
+        asyncio.set_event_loop(self.loop)
         self.client = self.server = None
-        self.queue = asyncio.Queue(loop=self.loop)
-        self.err_queue = asyncio.Queue(loop=self.loop)
+        self.queue = asyncio.Queue()
+        self.err_queue = asyncio.Queue()
 
     def tearDown(self):
         self.close_service(self.client)

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -328,7 +328,7 @@ class RpcTestsMixin(RpcMixin):
             server.close()
             client.close()
             await asyncio.gather(
-                server.wait_closed(), client.wait_closed(), loop=self.loop
+                server.wait_closed(), client.wait_closed()
             )
 
         self.loop.run_until_complete(communicate())
@@ -337,7 +337,7 @@ class RpcTestsMixin(RpcMixin):
         async def go():
             with self.assertRaises(TypeError):
                 await aiozmq.rpc.serve_rpc(
-                    "Bad Handler", bind="tcp://127.0.0.1:*", loop=self.loop
+                    "Bad Handler", bind="tcp://127.0.0.1:*"
                 )
 
         self.loop.run_until_complete(go())
@@ -445,7 +445,7 @@ class RpcTestsMixin(RpcMixin):
             )
 
             client = await aiozmq.rpc.connect_rpc(
-                connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                connect="tcp://127.0.0.1:{}".format(port)
             )
 
             with log_hook("aiozmq.rpc", self.err_queue):
@@ -472,7 +472,7 @@ class RpcTestsMixin(RpcMixin):
             )
 
             client = await aiozmq.rpc.connect_rpc(
-                connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                connect="tcp://127.0.0.1:{}".format(port)
             )
 
             with log_hook("aiozmq.rpc", self.err_queue):
@@ -499,7 +499,7 @@ class RpcTestsMixin(RpcMixin):
             )
 
             client = await aiozmq.rpc.connect_rpc(
-                connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                connect="tcp://127.0.0.1:{}".format(port)
             )
 
             with log_hook("aiozmq.rpc", self.err_queue):

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -49,7 +49,7 @@ class MyHandler(aiozmq.rpc.AttrHandler):
 
     @aiozmq.rpc.method
     async def slow_call(self):
-        await asyncio.sleep(0.2, loop=self.loop)
+        await asyncio.sleep(0.2)
 
     @aiozmq.rpc.method
     @asyncio.coroutine
@@ -68,7 +68,7 @@ class MyHandler(aiozmq.rpc.AttrHandler):
 
     @aiozmq.rpc.method
     async def not_so_fast(self):
-        await asyncio.sleep(0.001, loop=self.loop)
+        await asyncio.sleep(0.001)
         return "ok"
 
 
@@ -357,7 +357,7 @@ class RpcTestsMixin(RpcMixin):
                 loop=self.loop,
             )
 
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             with log_hook("aiozmq.rpc", self.err_queue):
                 tr.write([b"invalid", b"structure"])
@@ -593,13 +593,13 @@ class RpcTestsMixin(RpcMixin):
 
         async def communicate():
             waiter = client.call.fut()
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             self.assertEqual(1, len(server._proto.pending_waiters))
             task = next(iter(server._proto.pending_waiters))
             self.assertIsInstance(task, asyncio.Task)
             server.close()
             await server.wait_closed()
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             self.assertEqual(0, len(server._proto.pending_waiters))
             del waiter
 
@@ -664,7 +664,7 @@ class RpcTestsMixin(RpcMixin):
                 with self.assertRaises(asyncio.TimeoutError):
                     await client.with_timeout(0.1).call.slow_call()
 
-                await asyncio.sleep(0.3, loop=self.loop)
+                await asyncio.sleep(0.3)
 
                 ret = await client.call.func(2)
                 self.assertEqual(3, ret)

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -327,18 +327,14 @@ class RpcTestsMixin(RpcMixin):
             self.assertTrue(0.08 <= t1 - t0 <= 0.12, t1 - t0)
             server.close()
             client.close()
-            await asyncio.gather(
-                server.wait_closed(), client.wait_closed()
-            )
+            await asyncio.gather(server.wait_closed(), client.wait_closed())
 
         self.loop.run_until_complete(communicate())
 
     def test_type_of_handler(self):
         async def go():
             with self.assertRaises(TypeError):
-                await aiozmq.rpc.serve_rpc(
-                    "Bad Handler", bind="tcp://127.0.0.1:*"
-                )
+                await aiozmq.rpc.serve_rpc("Bad Handler", bind="tcp://127.0.0.1:*")
 
         self.loop.run_until_complete(go())
 

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -348,13 +348,11 @@ class RpcTestsMixin(RpcMixin):
             server = await aiozmq.rpc.serve_rpc(
                 MyHandler(self.loop),
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             tr, pr = await create_zmq_connection(
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 connect="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
 
             await asyncio.sleep(0.001)
@@ -379,13 +377,11 @@ class RpcTestsMixin(RpcMixin):
             server = await aiozmq.rpc.serve_rpc(
                 MyHandler(self.loop),
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             tr, pr = await create_zmq_connection(
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 connect="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
 
             with log_hook("aiozmq.rpc", self.err_queue):
@@ -410,13 +406,11 @@ class RpcTestsMixin(RpcMixin):
             server = await aiozmq.rpc.serve_rpc(
                 MyHandler(self.loop),
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             tr, pr = await create_zmq_connection(
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 connect="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
 
             with log_hook("aiozmq.rpc", self.err_queue):
@@ -448,7 +442,6 @@ class RpcTestsMixin(RpcMixin):
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
 
             client = await aiozmq.rpc.connect_rpc(
@@ -476,7 +469,6 @@ class RpcTestsMixin(RpcMixin):
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
 
             client = await aiozmq.rpc.connect_rpc(
@@ -504,7 +496,6 @@ class RpcTestsMixin(RpcMixin):
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
 
             client = await aiozmq.rpc.connect_rpc(

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -54,11 +54,11 @@ class MyHandler(aiozmq.rpc.AttrHandler):
     @aiozmq.rpc.method
     @asyncio.coroutine
     def fut(self):
-        return asyncio.Future(loop=self.loop)
+        return asyncio.Future()
 
     @aiozmq.rpc.method
     async def cancelled_fut(self):
-        ret = asyncio.Future(loop=self.loop)
+        ret = asyncio.Future()
         ret.cancel()
         return ret
 
@@ -75,10 +75,10 @@ class MyHandler(aiozmq.rpc.AttrHandler):
 class Protocol(aiozmq.ZmqProtocol):
     def __init__(self, loop):
         self.transport = None
-        self.connected = asyncio.Future(loop=loop)
-        self.closed = asyncio.Future(loop=loop)
+        self.connected = asyncio.Future()
+        self.closed = asyncio.Future()
         self.state = "INITIAL"
-        self.received = asyncio.Queue(loop=loop)
+        self.received = asyncio.Queue()
 
     def connection_made(self, transport):
         self.transport = transport
@@ -695,7 +695,7 @@ class LoopRpcTests(unittest.TestCase, RpcTestsMixin):
         self.loop = aiozmq.ZmqEventLoop()
         asyncio.set_event_loop(self.loop)
         self.client = self.server = None
-        self.err_queue = asyncio.Queue(loop=self.loop)
+        self.err_queue = asyncio.Queue()
 
     def tearDown(self):
         self.close_service(self.client)
@@ -710,7 +710,7 @@ class LoopLessRpcTests(unittest.TestCase, RpcTestsMixin):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         self.client = self.server = None
-        self.err_queue = asyncio.Queue(loop=self.loop)
+        self.err_queue = asyncio.Queue()
 
     def tearDown(self):
         self.close_service(self.client)

--- a/tests/rpc_translators_test.py
+++ b/tests/rpc_translators_test.py
@@ -42,12 +42,10 @@ class RpcTranslatorsMixin(RpcMixin):
             server = await aiozmq.rpc.serve_rpc(
                 MyHandler(),
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
                 translation_table=translation_table,
             )
             client = await aiozmq.rpc.connect_rpc(
                 connect="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
                 error_table=error_table,
                 translation_table=translation_table,
             )

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -161,6 +161,7 @@ class TestLoop(asyncio.base_events.BaseEventLoop):
 class TransportTests(unittest.TestCase):
     def setUp(self):
         self.loop = TestLoop()
+        asyncio.set_event_loop(self.loop)
         self.sock = mock.Mock()
         self.sock.closed = False
         self.proto = make_test_protocol(aiozmq.ZmqProtocol)
@@ -170,6 +171,7 @@ class TransportTests(unittest.TestCase):
 
     def tearDown(self):
         self.loop.close()
+        asyncio.set_event_loop(None)
 
     def test_empty_write(self):
         self.tr.write([b""])
@@ -717,9 +719,10 @@ class TransportTests(unittest.TestCase):
 class LooplessTransportTests(unittest.TestCase):
     def setUp(self):
         self.loop = TestLoop()
+        asyncio.set_event_loop(self.loop)
         self.sock = mock.Mock()
         self.sock.closed = False
-        self.waiter = asyncio.Future(loop=self.loop)
+        self.waiter = asyncio.Future()
         self.proto = make_test_protocol(aiozmq.ZmqProtocol)
         self.tr = _ZmqLooplessTransportImpl(
             self.loop, zmq.SUB, self.sock, self.proto, self.waiter
@@ -729,6 +732,7 @@ class LooplessTransportTests(unittest.TestCase):
 
     def tearDown(self):
         self.loop.close()
+        asyncio.set_event_loop(None)
 
     def test_incomplete_read(self):
         self.sock.recv_multipart.side_effect = zmq.Again(errno.EAGAIN)

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -51,7 +51,6 @@ class BaseZmqEventLoopTestsMixin:
             lambda: Protocol(self.loop),
             zmq.DEALER,
             bind="tcp://127.0.0.1:{}".format(port),
-            loop=self.loop,
         )
         self.assertEqual("CONNECTED", pr1.state)
         await pr1.connected
@@ -60,7 +59,6 @@ class BaseZmqEventLoopTestsMixin:
             lambda: Protocol(self.loop),
             zmq.ROUTER,
             connect="tcp://127.0.0.1:{}".format(port),
-            loop=self.loop,
         )
         self.assertEqual("CONNECTED", pr2.state)
         await pr2.connected
@@ -74,7 +72,6 @@ class BaseZmqEventLoopTestsMixin:
             lambda: Protocol(self.loop),
             zmq.PUB,
             bind="tcp://127.0.0.1:{}".format(port),
-            loop=self.loop,
         )
         self.assertEqual("CONNECTED", pr1.state)
         await pr1.connected
@@ -83,7 +80,6 @@ class BaseZmqEventLoopTestsMixin:
             lambda: Protocol(self.loop),
             zmq.SUB,
             connect="tcp://127.0.0.1:{}".format(port),
-            loop=self.loop,
         )
         self.assertEqual("CONNECTED", pr2.state)
         await pr2.connected
@@ -96,7 +92,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="inproc://test",
-                loop=self.loop,
             )
             self.assertEqual("CONNECTED", pr1.state)
             await pr1.connected
@@ -109,7 +104,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REP,
                 connect="inproc://test",
-                loop=self.loop,
             )
             self.assertEqual("CONNECTED", pr2.state)
             await pr2.connected
@@ -175,7 +169,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await pr.connected
             self.assertEqual(zmq.DEALER, tr.getsockopt(zmq.TYPE))
@@ -214,7 +207,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind=[addr1, addr2],
-                loop=self.loop,
             )
             await pr.connected
 
@@ -245,7 +237,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 connect=[addr1, addr2],
-                loop=self.loop,
             )
             await pr.connected
 
@@ -340,7 +331,6 @@ class BaseZmqEventLoopTestsMixin:
                     lambda: Protocol(self.loop),
                     zmq.SUB,
                     connect="badaddr",
-                    loop=self.loop,
                 )
 
         self.loop.run_until_complete(connect())
@@ -368,7 +358,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.SUB,
                 connect="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await pr.connected
             return tr, pr
@@ -387,7 +376,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.SUB,
                 connect="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await pr.connected
             return tr, pr
@@ -452,7 +440,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.PUSH,
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             await pr.connected
             return tr, pr
@@ -468,7 +455,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.SUB,
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             await pr.connected
             return tr, pr
@@ -486,7 +472,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.SUB,
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             await pr.connected
             return tr, pr
@@ -511,7 +496,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.SUB,
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             await pr.connected
             return tr, pr
@@ -529,7 +513,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.PUSH,
                 bind="tcp://127.0.0.1:*",
-                loop=self.loop,
             )
             await pr.connected
 
@@ -610,7 +593,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         tr1.close()
@@ -625,7 +607,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         self.assertFalse(tr1._paused)
@@ -642,7 +623,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         tr1.close()
@@ -656,7 +636,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         tr1.pause_reading()
@@ -672,7 +651,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         with self.assertRaises(RuntimeError):
@@ -687,7 +665,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         self.assertEqual(0, tr1._conn_lost)
@@ -708,7 +685,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         handler = mock.Mock()
@@ -740,7 +716,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         handler = mock.Mock()
@@ -758,7 +733,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await pr.connected
             self.assertRegex(
@@ -778,7 +752,6 @@ class BaseZmqEventLoopTestsMixin:
                 lambda: Protocol(self.loop),
                 zmq.DEALER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await pr.connected
 
@@ -868,7 +841,6 @@ class ZmqLooplessTests(BaseZmqEventLoopTestsMixin, unittest.TestCase):
                 lambda: Protocol(self.loop),
                 zmq.REQ,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
         )
         handler = mock.Mock()
@@ -900,7 +872,6 @@ class ZmqEventLoopExternalContextTests(unittest.TestCase):
                 lambda: Protocol(self.loop),
                 zmq.ROUTER,
                 bind="tcp://127.0.0.1:{}".format(port),
-                loop=self.loop,
             )
             await sp.connected
             addr = list(st.bindings())[0]

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -13,10 +13,10 @@ from aiozmq._test_util import check_errno, find_unused_port
 class Protocol(aiozmq.ZmqProtocol):
     def __init__(self, loop):
         self.transport = None
-        self.connected = asyncio.Future(loop=loop)
-        self.closed = asyncio.Future(loop=loop)
+        self.connected = asyncio.Future()
+        self.closed = asyncio.Future()
         self.state = "INITIAL"
-        self.received = asyncio.Queue(loop=loop)
+        self.received = asyncio.Queue()
         self.paused = False
 
     def connection_made(self, transport):
@@ -843,7 +843,7 @@ class BaseZmqEventLoopTestsMixin:
 class ZmqEventLoopTests(BaseZmqEventLoopTestsMixin, unittest.TestCase):
     def setUp(self):
         self.loop = aiozmq.ZmqEventLoop()
-        asyncio.set_event_loop(None)
+        asyncio.set_event_loop(self.loop)
 
     def tearDown(self):
         self.loop.close()
@@ -854,7 +854,7 @@ class ZmqEventLoopTests(BaseZmqEventLoopTestsMixin, unittest.TestCase):
 class ZmqLooplessTests(BaseZmqEventLoopTestsMixin, unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
+        asyncio.set_event_loop(self.loop)
 
     def tearDown(self):
         self.loop.close()

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -142,9 +142,7 @@ class BaseZmqEventLoopTestsMixin:
             for i in range(5):
                 tr1.write([b"node_id", b"publish"])
                 try:
-                    request = await asyncio.wait_for(
-                        pr2.received.get(), 0.1
-                    )
+                    request = await asyncio.wait_for(pr2.received.get(), 0.1)
                     self.assertEqual([b"node_id", b"publish"], request)
                     break
                 except asyncio.TimeoutError:

--- a/tests/zmq_events_test.py
+++ b/tests/zmq_events_test.py
@@ -143,7 +143,7 @@ class BaseZmqEventLoopTestsMixin:
                 tr1.write([b"node_id", b"publish"])
                 try:
                     request = await asyncio.wait_for(
-                        pr2.received.get(), 0.1, loop=self.loop
+                        pr2.received.get(), 0.1
                     )
                     self.assertEqual([b"node_id", b"publish"], request)
                     break
@@ -254,7 +254,7 @@ class BaseZmqEventLoopTestsMixin:
 
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.PUB, zmq_sock=zmq_sock, loop=self.loop
+                lambda: Protocol(self.loop), zmq.PUB, zmq_sock=zmq_sock
             )
             await pr.connected
             return tr, pr
@@ -269,7 +269,7 @@ class BaseZmqEventLoopTestsMixin:
 
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, zmq_sock=zmq_sock, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, zmq_sock=zmq_sock
             )
             await pr.connected
             return tr, pr
@@ -284,7 +284,7 @@ class BaseZmqEventLoopTestsMixin:
 
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, zmq_sock=zmq_sock, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, zmq_sock=zmq_sock
             )
             await pr.connected
             return tr, pr
@@ -296,7 +296,7 @@ class BaseZmqEventLoopTestsMixin:
     def test_create_zmq_connection_invalid_bind(self):
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, bind=2, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, bind=2
             )
 
         with self.assertRaises(ValueError):
@@ -305,7 +305,7 @@ class BaseZmqEventLoopTestsMixin:
     def test_create_zmq_connection_invalid_connect(self):
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, connect=2, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, connect=2
             )
 
         with self.assertRaises(ValueError):
@@ -315,7 +315,7 @@ class BaseZmqEventLoopTestsMixin:
     def test_create_zmq_connection_closes_socket_on_bad_bind(self):
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, bind="badaddr", loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, bind="badaddr"
             )
             await pr.connected
             return tr, pr
@@ -341,7 +341,7 @@ class BaseZmqEventLoopTestsMixin:
         async def connect():
             addr = "tcp://localhost:{}".format(port)
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, connect=addr, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, connect=addr
             )
             await pr.connected
 
@@ -392,7 +392,7 @@ class BaseZmqEventLoopTestsMixin:
 
         async def connect():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, bind=addr, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, bind=addr
             )
             await pr.connected
 
@@ -416,7 +416,7 @@ class BaseZmqEventLoopTestsMixin:
 
         async def go():
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.SUB, connect=addr, loop=self.loop
+                lambda: Protocol(self.loop), zmq.SUB, connect=addr
             )
             await pr.connected
 
@@ -773,7 +773,7 @@ class BaseZmqEventLoopTestsMixin:
         async def go():
 
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.DEALER, loop=self.loop
+                lambda: Protocol(self.loop), zmq.DEALER
             )
             await pr.connected
 
@@ -799,7 +799,7 @@ class BaseZmqEventLoopTestsMixin:
         async def go():
 
             tr, pr = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.DEALER, loop=self.loop
+                lambda: Protocol(self.loop), zmq.DEALER
             )
             await pr.connected
 
@@ -877,7 +877,7 @@ class ZmqEventLoopExternalContextTests(unittest.TestCase):
             addr = list(st.bindings())[0]
 
             ct, cp = await aiozmq.create_zmq_connection(
-                lambda: Protocol(self.loop), zmq.DEALER, connect=addr, loop=self.loop
+                lambda: Protocol(self.loop), zmq.DEALER, connect=addr
             )
             await cp.connected
 

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -63,9 +63,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_transport(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             self.assertIsInstance(s1.transport, aiozmq.ZmqTransport)
             s1.close()
@@ -77,9 +75,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_get_extra_info(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             self.assertIsInstance(s1.get_extra_info("zmq_socket"), zmq.Socket)
 
@@ -87,9 +83,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_exception(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             self.assertIsNone(s1.exception())
 
@@ -107,9 +101,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_set_read_buffer_limits1(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             s1.set_read_buffer_limits(low=10)
             self.assertEqual(10, s1._low_water)
@@ -121,9 +113,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_set_read_buffer_limits2(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             s1.set_read_buffer_limits(high=60)
             self.assertEqual(15, s1._low_water)
@@ -135,9 +125,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_set_read_buffer_limits3(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             with self.assertRaises(ValueError):
                 s1.set_read_buffer_limits(high=1, low=2)
@@ -172,9 +160,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_set_exception(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             exc = RuntimeError("some exc")
             s1.set_exception(exc)
@@ -187,9 +173,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_set_exception_with_waiter(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             async def f():
                 await s1.read()
@@ -213,9 +197,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_set_exception_with_cancelled_waiter(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             async def f():
                 await s1.read()
@@ -238,9 +220,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_double_reading(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             async def f():
                 await s1.read()
@@ -557,9 +537,7 @@ class ZmqStreamTests(unittest.TestCase):
 
     def test_default_events_backlog(self):
         async def go():
-            s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*"
-            )
+            s1 = await aiozmq.create_zmq_stream(zmq.DEALER, bind="tcp://127.0.0.1:*")
 
             self.assertEqual(100, s1._event_queue.maxlen)
 

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -24,11 +24,11 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             s2 = await aiozmq.create_zmq_stream(
-                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port)
             )
 
             s1.write([b"request"])
@@ -45,11 +45,11 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             s2 = await aiozmq.create_zmq_stream(
-                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port)
             )
 
             self.assertFalse(s2.at_closing())
@@ -64,7 +64,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_transport(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             self.assertIsInstance(s1.transport, aiozmq.ZmqTransport)
@@ -78,7 +78,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_get_extra_info(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             self.assertIsInstance(s1.get_extra_info("zmq_socket"), zmq.Socket)
@@ -88,7 +88,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_exception(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             self.assertIsNone(s1.exception())
@@ -108,7 +108,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_set_read_buffer_limits1(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             s1.set_read_buffer_limits(low=10)
@@ -122,7 +122,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_set_read_buffer_limits2(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             s1.set_read_buffer_limits(high=60)
@@ -136,7 +136,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_set_read_buffer_limits3(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             with self.assertRaises(ValueError):
@@ -151,11 +151,11 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             s2 = await aiozmq.create_zmq_stream(
-                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port)
             )
 
             s2.set_read_buffer_limits(high=5)
@@ -173,7 +173,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_set_exception(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             exc = RuntimeError("some exc")
@@ -188,7 +188,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_set_exception_with_waiter(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             async def f():
@@ -214,7 +214,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_set_exception_with_cancelled_waiter(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             async def f():
@@ -239,7 +239,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_double_reading(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             async def f():
@@ -261,7 +261,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             async def f():
@@ -284,7 +284,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             async def f():
@@ -308,7 +308,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             async def f():
@@ -335,7 +335,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.REP, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.REP, bind="tcp://127.0.0.1:{}".format(port)
             )
             handler = mock.Mock()
             self.loop.set_exception_handler(handler)
@@ -354,7 +354,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.REP, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.REP, bind="tcp://127.0.0.1:{}".format(port)
             )
             await s1.drain()
 
@@ -365,7 +365,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             self.assertFalse(s1._paused)
@@ -382,7 +382,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             self.assertFalse(s1._paused)
@@ -409,7 +409,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             s1._protocol.pause_writing()
@@ -422,7 +422,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             self.assertFalse(s1._paused)
@@ -444,7 +444,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             s1.close()
@@ -460,7 +460,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:{}".format(port)
             )
 
             self.assertFalse(s1._paused)
@@ -485,7 +485,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             s2 = await aiozmq.create_zmq_stream(
-                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port), loop=self.loop
+                zmq.ROUTER, connect="tcp://127.0.0.1:{}".format(port)
             )
 
             self.assertFalse(s2.at_closing())
@@ -514,7 +514,7 @@ class ZmqStreamTests(unittest.TestCase):
 
         async def go():
             addr = "tcp://127.0.0.1:{}".format(port)
-            s1 = await aiozmq.create_zmq_stream(zmq.ROUTER, bind=addr, loop=self.loop)
+            s1 = await aiozmq.create_zmq_stream(zmq.ROUTER, bind=addr)
 
             async def f(s, events):
                 try:
@@ -524,10 +524,10 @@ class ZmqStreamTests(unittest.TestCase):
                 except aiozmq.ZmqStreamClosed:
                     pass
 
-            s2 = await aiozmq.create_zmq_stream(zmq.DEALER, loop=self.loop)
+            s2 = await aiozmq.create_zmq_stream(zmq.DEALER)
 
             events = []
-            t = ensure_future(f(s2, events), loop=self.loop)
+            t = ensure_future(f(s2, events))
 
             await s2.transport.enable_monitor()
             await s2.transport.connect(addr)
@@ -558,7 +558,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_default_events_backlog(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop
+                zmq.DEALER, bind="tcp://127.0.0.1:*"
             )
 
             self.assertEqual(100, s1._event_queue.maxlen)

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -568,7 +568,7 @@ class ZmqStreamTests(unittest.TestCase):
     def test_custom_events_backlog(self):
         async def go():
             s1 = await aiozmq.create_zmq_stream(
-                zmq.DEALER, bind="tcp://127.0.0.1:*", loop=self.loop, events_backlog=1
+                zmq.DEALER, bind="tcp://127.0.0.1:*", events_backlog=1
             )
 
             self.assertEqual(1, s1._event_queue.maxlen)

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -194,7 +194,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.read()
 
-            t1 = ensure_future(f(), loop=self.loop)
+            t1 = ensure_future(f())
             # to run f() up to await
             await asyncio.sleep(0.001)
 
@@ -220,7 +220,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.read()
 
-            t1 = ensure_future(f(), loop=self.loop)
+            t1 = ensure_future(f())
             # to run f() up to await
             await asyncio.sleep(0.001)
 
@@ -245,7 +245,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.read()
 
-            t1 = ensure_future(f(), loop=self.loop)
+            t1 = ensure_future(f())
             # to run f() up to await
             await asyncio.sleep(0.001)
 
@@ -267,7 +267,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.read()
 
-            t1 = ensure_future(f(), loop=self.loop)
+            t1 = ensure_future(f())
             # to run f() up to await
             await asyncio.sleep(0.001)
 
@@ -290,7 +290,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.read()
 
-            t1 = ensure_future(f(), loop=self.loop)
+            t1 = ensure_future(f())
             # to run f() up to await
             await asyncio.sleep(0.001)
 
@@ -314,7 +314,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.read()
 
-            t1 = ensure_future(f(), loop=self.loop)
+            t1 = ensure_future(f())
             # to run f() up to await
             await asyncio.sleep(0.001)
 
@@ -391,7 +391,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.drain()
 
-            fut = ensure_future(f(), loop=self.loop)
+            fut = ensure_future(f())
             await asyncio.sleep(0.01)
 
             self.assertTrue(s1._protocol._paused)
@@ -431,7 +431,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.drain()
 
-            fut = ensure_future(f(), loop=self.loop)
+            fut = ensure_future(f())
             await asyncio.sleep(0.01)
 
             s1.close()
@@ -469,7 +469,7 @@ class ZmqStreamTests(unittest.TestCase):
             async def f():
                 await s1.drain()
 
-            fut = ensure_future(f(), loop=self.loop)
+            fut = ensure_future(f())
             await asyncio.sleep(0.01)
 
             exc = RuntimeError("exception")

--- a/tests/zmq_stream_test.py
+++ b/tests/zmq_stream_test.py
@@ -161,7 +161,7 @@ class ZmqStreamTests(unittest.TestCase):
             s2.set_read_buffer_limits(high=5)
             s1.write([b"request"])
 
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             self.assertTrue(s2._paused)
 
             msg = await s2.read()
@@ -196,7 +196,7 @@ class ZmqStreamTests(unittest.TestCase):
 
             t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to await
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             self.assertIsNotNone(s1._waiter)
 
@@ -222,7 +222,7 @@ class ZmqStreamTests(unittest.TestCase):
 
             t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to await
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             self.assertIsNotNone(s1._waiter)
             t1.cancel()
@@ -247,7 +247,7 @@ class ZmqStreamTests(unittest.TestCase):
 
             t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to await
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             with self.assertRaises(RuntimeError):
                 await s1.read()
@@ -269,10 +269,10 @@ class ZmqStreamTests(unittest.TestCase):
 
             t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to await
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             s1.close()
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             with self.assertRaises(aiozmq.ZmqStreamClosed):
                 t1.result()
@@ -292,12 +292,12 @@ class ZmqStreamTests(unittest.TestCase):
 
             t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to await
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             t1.cancel()
             s1.feed_closing()
 
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
             with self.assertRaises(asyncio.CancelledError):
                 t1.result()
 
@@ -316,12 +316,12 @@ class ZmqStreamTests(unittest.TestCase):
 
             t1 = ensure_future(f(), loop=self.loop)
             # to run f() up to await
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
 
             t1.cancel()
             s1.feed_msg([b"data"])
 
-            await asyncio.sleep(0.001, loop=self.loop)
+            await asyncio.sleep(0.001)
             with self.assertRaises(asyncio.CancelledError):
                 t1.result()
 
@@ -392,7 +392,7 @@ class ZmqStreamTests(unittest.TestCase):
                 await s1.drain()
 
             fut = ensure_future(f(), loop=self.loop)
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
 
             self.assertTrue(s1._protocol._paused)
             s1._protocol.resume_writing()
@@ -432,7 +432,7 @@ class ZmqStreamTests(unittest.TestCase):
                 await s1.drain()
 
             fut = ensure_future(f(), loop=self.loop)
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
 
             s1.close()
             await fut
@@ -448,7 +448,7 @@ class ZmqStreamTests(unittest.TestCase):
             )
 
             s1.close()
-            await asyncio.sleep(0, loop=self.loop)
+            await asyncio.sleep(0)
 
             with self.assertRaises(ConnectionResetError):
                 await s1.drain()
@@ -470,7 +470,7 @@ class ZmqStreamTests(unittest.TestCase):
                 await s1.drain()
 
             fut = ensure_future(f(), loop=self.loop)
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
 
             exc = RuntimeError("exception")
             s1._protocol.connection_lost(exc)


### PR DESCRIPTION
Mostly in unit tests so far.