### PR TITLE
Fix Python version detection in runtests.py (broken for Python 3.10)

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -39,7 +39,7 @@ except ImportError:
 
 from unittest.signals import installHandler
 
-assert sys.version >= "3.3", "Please use Python 3.3 or higher."
+assert sys.version_info >= (3, 3), "Please use Python 3.3 or higher."
 
 ARGS = argparse.ArgumentParser(description="Run all unittests.")
 ARGS.add_argument(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Compare versions as tuples instead of strings, so that Python 3.10 is detected as >= Python 3.3.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Tests work on Python 3.10 instead of complaining that Python 3.3 or higher is needed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

Is all that documentation really needed for such a trivial fix?