### PR TITLE
Remove deprecated loop argument for asyncio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         msgpack: ['', '1']
         debug: ['', '1']
 

--- a/aiozmq/rpc/util.py
+++ b/aiozmq/rpc/util.py
@@ -20,10 +20,7 @@ class _MethodCall:
         if not self._names:
             raise ValueError("RPC method name is empty")
         fut = self._proto.call(".".join(self._names), args, kwargs)
-        loop = self._proto.loop
-        return asyncio.Task(
-            asyncio.wait_for(fut, timeout=self._timeout, loop=loop), loop=loop
-        )
+        return asyncio.Task(asyncio.wait_for(fut, timeout=self._timeout))
 
 
 def _fill_error_table():

--- a/tests/rpc_pubsub_test.py
+++ b/tests/rpc_pubsub_test.py
@@ -86,7 +86,7 @@ class PubSubTestsMixin(RpcMixin):
                 for i in range(3):
                     try:
                         await client.publish(pub).start()
-                        ret = await asyncio.wait_for(self.queue.get(), 0.1, loop=loop)
+                        ret = await asyncio.wait_for(self.queue.get(), 0.1)
                         self.assertEqual(ret, "started")
                         break
                     except asyncio.TimeoutError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This tries to make it possible to use `aiozmq` on python 3.10 by removing the explicit loop parameter that has been deprecated for a while and removed in 3.10.
The approach used was quite simple, I used python3.10 and ran `python runtests.py` until the tests started passing.
There is still a fair number of warnings, but I am not entirely sure what the correct approach to those are or if they perhaps fall outside of the scope of this - I am trying to keep the changes minimal, partly due to the fact that I am not familiar with how the internals work.

However, I have not removed the loop parameter from the public API as that might make migration more difficult for users - even if the parameter should be meaningless with these changes.

I hope this is reasonable, but let me know if there is something that I have missed that needs to be addressed.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
There should not be - but if there is, I will try to correct it.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
I believe this would resolve:
- #175
- #172

And it would perhaps go some way to address the changes needed for: 
- #166
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
