### PR TITLE
Running tests as is

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: install python dependencies
       run: |
         pip install --upgrade pip setuptools wheel && \
-        python setup.py install && \
+        pip install .
         test ${{ matrix.msgpack }} == 1 && pip install msgpack; \
         pip install pyflakes pycodestyle docutils codecov black==22.8.0
     - name: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
         msgpack: ['', '1']
         debug: ['', '1']
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [master]
+    branches: [master, "*"]
     tags: ['*']
   pull_request:
     paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [master, "*"]
+    branches: [master]
     tags: ['*']
   pull_request:
     paths-ignore:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

While trying to figure out how to make this able to run using python 3.14 I noticed that I could not even get the tests to run as they currently are.

This is an attempt to get the tests running mostly as they are with the absolute minimal required changes.

The `ubuntu-latest` github actions runner did not have many older python versions available, downgrading to `ubuntu-22.04` seemed to fix that, although I had to drop python 3.6 to get it running.
I tried downgrading all the way to `ubuntu-18.04` but that did not even run, I don't think github still has those runners available anymore.

In addition, newer versions python did not install `pyzmq` properly, and I had to switch `python setup.py install` with `pip install .`, I am not an expert on packaging python libraries, so it is very likely there is an even better approach, suggestions for improvements welcome.

## Are there changes in behavior for the user?

This does remove testing for python 3.6, that might be bad?

## Related issue number

No issue for the state of the tests exists as far as I know, and I have not finished writing an issue for the problems regarding upgrading to python 3.14, partly because having the tests not running adds extra noise to that issue, and I think it would be better to have that part solved up front.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
